### PR TITLE
Global translations

### DIFF
--- a/utils/translator/readme.md
+++ b/utils/translator/readme.md
@@ -1,0 +1,28 @@
+This is a translator utility that we can reuse in many different place here's how it works. If You have the following translations
+``` javascript
+const exampleTranslations = {
+    'simple': {
+        en: 'Hi, Tester',
+        sw: 'Niaje, Tester'
+    },
+    'another': {
+        fr: 'bonjour',
+        de: 'Guten tag'
+    },
+    'preferred-name-prompt': {
+        en: 'Should I call you $firstName or $lastName',
+        sw: 'Ninapaswa Kukuita $firstName au $lastName',
+    }
+};
+```
+
+you can create a translator out of it as follows
+``` javascript
+const createTranslator = require('./translator');
+const translate = createTranslator(exampleTranslations)
+```
+
+and then get translations like this
+```javascript
+const englishText = translate('preferred-name-prompt','en',{ '$firstname': 'Peter', '$lastName': 'Parker'});
+```

--- a/utils/translator/translator.js
+++ b/utils/translator/translator.js
@@ -1,0 +1,27 @@
+function escapeRegExp(string) {
+    return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&');
+}
+function replaceAll(str, find, replace) {
+    return str.replace(new RegExp(escapeRegExp(find), 'g'), replace);
+}
+
+function createTranslator(translations, defaultLanguage) {
+    if (!translations) throw new Error('No Translations Provided');
+    if (!defaultLanguage) throw new Error('No default language provided');
+    var translate = function (key, lang, options) {
+        var entry = translations[key];
+        if (entry === undefined) throw 'No Entry For "' + key + '"';
+        var template = entry[lang] || entry[defaultLanguage];
+        if (template === undefined) throw 'No "' + lang + '" or "' + defaultLanguage + '" Translations For "' + key + '"';
+        var text = template;
+        if (options) {
+            Object.keys(options).forEach(function (subKey) {
+                text = replaceAll(text, subKey, options[subKey]);
+            });
+        }
+        return text;
+    };
+    return translate;
+}
+
+module.exports = createTranslator;

--- a/utils/translator/translator.test.js
+++ b/utils/translator/translator.test.js
@@ -1,0 +1,66 @@
+const createTranslator = require('./translator');
+
+const exampleTranslations = {
+    'simple': {
+        en: 'Hi, Tester',
+        sw: 'Niaje, Tester'
+    },
+    'another': {
+        fr: 'bonjour',
+        de: 'Guten tag'
+    },
+    'with-substitutions': {
+        en: 'Should I call you $firstName or $lastName',
+        sw: 'Ninapaswa Kukuita $firstName au $lastName',
+    }
+};
+
+describe('createTranslator', () => {
+    it('should be a function', () => {
+        expect(createTranslator).toBeInstanceOf(Function);
+    });
+    it('should throw an error if there is no translations object', () => {
+        expect(() => {
+            createTranslator();
+        }).toThrow('No Translations Provided');
+    });
+    it('should throw an error if there is no default tranlation key', () => {
+        expect(() => {
+            createTranslator(exampleTranslations);
+        }).toThrow('No default language provided');
+    });
+    it('should return a translate function', () => {
+        expect(createTranslator(exampleTranslations,'en')).toBeInstanceOf(Function);        
+    });
+    describe('translate', () => {
+        var translate;
+        beforeEach(() => {
+            translate = createTranslator(exampleTranslations,'en');
+        });
+        it('should return the default translation if no language is provided', () => {
+            expect(translate('simple')).toEqual(exampleTranslations.simple.en);
+        });
+        it('should return the selected language translation', () => {
+            expect(translate('simple','sw')).toEqual(exampleTranslations.simple.sw);
+        });
+        it('should throw an error if there is no text matching the translations  ', () => {
+            expect(() => {
+                translate('non-existent','sw');
+            }).toThrowError('No Entry For "non-existent"');
+        });
+        it('should return the default translation if non exists for the language provided', () => {
+            expect(translate('simple','ki')).toEqual(exampleTranslations.simple.en);
+        });
+        it('should throw an error if no translation exists in the default or given language', () => {
+            expect(() => {
+                translate('another','sw');
+            }).toThrowError('No "sw" or "en" Translations For "another"');
+        });
+        it('should replace template placeholders with corresponding values from options', () => {
+            expect(translate('with-substitutions','en',{$firstName: 'clark',$lastName: 'kent'})).toEqual(
+                'Should I call you clark or kent'
+            );
+        });
+        
+    });
+});


### PR DESCRIPTION
This is a translator utility that we can reuse in many different place here's how it works. If You have the following translations
``` javascript
const exampleTranslations = {
    'simple': {
        en: 'Hi, Tester',
        sw: 'Niaje, Tester'
    },
    'another': {
        fr: 'bonjour',
        de: 'Guten tag'
    },
    'preferred-name-prompt': {
        en: 'Should I call you $firstName or $lastName',
        sw: 'Ninapaswa Kukuita $firstName au $lastName',
    }
};
```

you can create a translator out of it as follows
``` javascript
const createTranslator = require('./translator');
const translate = createTranslator(exampleTranslations)
```

and then get translations like this
```javascript
const englishText = translate('preferred-name-prompt','en',{ '$firstname': 'Peter', '$lastName': 'Parker'});
```