### PR TITLE
Refactoring of the translator utility

### DIFF
--- a/utils/translator/translator.js
+++ b/utils/translator/translator.js
@@ -8,13 +8,13 @@ function replaceAll(str, find, replace) {
 function createTranslator(translations, defaultLanguage) {
     if (!translations) throw new Error('No Translations Provided');
     if (!defaultLanguage) throw new Error('No default language provided');
-    var translate = function (key, lang, options) {
+    var translate = function (key, options, lang) {
         var entry = translations[key];
         if (entry === undefined) throw 'No Entry For "' + key + '"';
         var template = entry[lang] || entry[defaultLanguage];
         if (template === undefined) throw 'No "' + lang + '" or "' + defaultLanguage + '" Translations For "' + key + '"';
         var text = template;
-        if (options) {
+        if (options && Object.keys(options).length > 0) {
             Object.keys(options).forEach(function (subKey) {
                 text = replaceAll(text, subKey, options[subKey]);
             });

--- a/utils/translator/translator.test.js
+++ b/utils/translator/translator.test.js
@@ -41,23 +41,23 @@ describe('createTranslator', () => {
             expect(translate('simple')).toEqual(exampleTranslations.simple.en);
         });
         it('should return the selected language translation', () => {
-            expect(translate('simple','sw')).toEqual(exampleTranslations.simple.sw);
+            expect(translate('simple', {}, 'sw')).toEqual(exampleTranslations.simple.sw);
         });
         it('should throw an error if there is no text matching the translations  ', () => {
             expect(() => {
-                translate('non-existent','sw');
+                translate('non-existent', {}, 'sw');
             }).toThrowError('No Entry For "non-existent"');
         });
         it('should return the default translation if non exists for the language provided', () => {
-            expect(translate('simple','ki')).toEqual(exampleTranslations.simple.en);
+            expect(translate('simple', {}, 'ki')).toEqual(exampleTranslations.simple.en);
         });
         it('should throw an error if no translation exists in the default or given language', () => {
             expect(() => {
-                translate('another','sw');
+                translate('another', {}, 'sw');
             }).toThrowError('No "sw" or "en" Translations For "another"');
         });
         it('should replace template placeholders with corresponding values from options', () => {
-            expect(translate('with-substitutions','en',{$firstName: 'clark',$lastName: 'kent'})).toEqual(
+            expect(translate('with-substitutions', {$firstName: 'clark',$lastName: 'kent'}, 'en')).toEqual(
                 'Should I call you clark or kent'
             );
         });


### PR DESCRIPTION
currently the translator utility is called like this 
call(key, lang, options)

changed it to
call(key, options, lang)

purpose. 
this is for better implementation when we want to omit the lang since it is sometimes set to default hence optional.