### PR TITLE
Add transaction history support to Kenya

### DIFF
--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -995,10 +995,10 @@ var SplashMenuFailure = function (){
     if (GetLang()){sayText("Incorrect input. Please enter the 8 digit account number you use for repayment\nPress 0 if you do not have an OAF account\n99) Swahili")}
     else {sayText("Nambari sio sahihi. Tafadhali ingiza nambari 8 za akaunti yako ambayo unatumia kufanya malipo.\nBonyeza 0 kama hauna akaunti ya OAF\n99) English")}
 };
+var MenuText = '';
 var MainMenuText = function (client){
-    var MenuText = "";
-    if (GetLang()){MenuText ="Select Service\n1) Make a payment\n2) Check balance\n3) Trainings"}
-    else {MenuText ="Chagua Huduma\n1) Fanya malipo\n2) Kuangalia salio\n3) Mafunzo"}
+    if (GetLang()){MenuText ='Select Service\n1) Make a payment\n2) Check balance\n3) Trainings\n4) View transaction history';}
+    else {MenuText ='Chagua Huduma\n1) Fanya malipo\n2) Kuangalia salio\n3) Mafunzo\n4) Angalia historia ya malipo';}
     var JITActive = true;
     var FAWActiveCheck = true;
     //if (IsGl(client.AccountNumber)){

--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -1,4 +1,23 @@
+var defaultEnvironment;
+if(service.active){
+    defaultEnvironment = 'prod';
+}else{
+    defaultEnvironment = 'dev';
+}
+
+var env;
+if(service.vars.env === 'prod' || service.vars.env === 'dev'){
+    env = service.vars.env;
+}else{
+    env = defaultEnvironment;
+}
+
+service.vars.server_name = project.vars[env+'_server_name'];
+service.vars.roster_api_key = project.vars[env+'_roster_api_key'];
+
+
 var transactionHistory = require('../transaction-history/index');
+
 // Setting global variables!
 var rosterAPI = require('ext/Roster_v1_2_0/api');
 var translatorFactory = require('../utils/translator/translator');

--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -1630,8 +1630,10 @@ global.main = function () {
 }
 
 // load input handlers
-dukaLocator.registerDukaLocatorHandlers({lang: GetLang() ? 'en' : 'sw'})
-addInputHandler("SplashMenu", function(SplashMenu) {
+dukaLocator.registerDukaLocatorHandlers({lang: GetLang() ? 'en' : 'sw'});
+transactionHistory.registerHandlers();
+
+addInputHandler('SplashMenu', function(SplashMenu) {
     LogSessionID();
     InteractionCounter("SplashMenu");
     ClientAccNum = SplashMenu;

--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -1,3 +1,4 @@
+var transactionHistory = require('../transaction-history/index');
 // Setting global variables!
 var rosterAPI = require('ext/Roster_v1_2_0/api');
 var translatorFactory = require('../utils/translator/translator');
@@ -134,11 +135,23 @@ var TrimClientJSON = function(client){
     return client;
 };
 var GetLang = function(){
-    if(contact.vars.English === true){return true} else {return false}
+    if(contact.vars.English === true){
+        service.vars.lang = 'en';
+        return true;
+    } else {
+        service.vars.lang = 'sw';
+        return false;
+    }
 };
 var ChangeLang = function (){
-    if (contact.vars.English === true){contact.vars.English = false}
-    else {contact.vars.English = true}
+    if (contact.vars.English === true){
+        service.vars.lang = 'sw';
+        contact.vars.English = false;
+    }
+    else {
+        service.vars.lang = 'en';
+        contact.vars.English = true;
+    }
     contact.save();
 };
 var RosterClientVal = function (AccNum){
@@ -1682,7 +1695,9 @@ addInputHandler("MainMenu", function(MainMenu) {
     }
     else if(MainMenu == 3){
         TrainingMenuText();
-        promptDigits("TrainingSelect", {submitOnHash: true, maxDigits: 1, timeout: 5})
+    }
+    else if(MainMenu == 4){
+        transactionHistory.start(client.AccountNumber, 'ke');
     }
     //else if(MainMenu == 3 && IsGl(client.AccountNumber)&&IsJITTUDistrict(client.DistrictName)){
       //      if (SiteLockVal (client.SiteName, client.DistrictName)){

--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -155,8 +155,8 @@ var TrimClientJSON = function(client){
 };
 var GetLang = function(){
     if(contact.vars.English === true){
-        service.vars.lang = 'en';
-        contact.vars.lang = 'en';
+        service.vars.lang = 'en-ke';
+        contact.vars.lang = 'en-ke';
         return true;
     } else {
         service.vars.lang = 'sw';
@@ -170,7 +170,7 @@ var ChangeLang = function (){
         contact.vars.lang = 'sw';
     }
     else {
-        contact.vars.lang = 'en';
+        contact.vars.lang = 'en-ke';
         contact.vars.English = true;
     }
     contact.save();

--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -156,19 +156,21 @@ var TrimClientJSON = function(client){
 var GetLang = function(){
     if(contact.vars.English === true){
         service.vars.lang = 'en';
+        contact.vars.lang = 'en';
         return true;
     } else {
         service.vars.lang = 'sw';
+        contact.vars.lang = 'sw';
         return false;
     }
 };
 var ChangeLang = function (){
     if (contact.vars.English === true){
-        service.vars.lang = 'sw';
         contact.vars.English = false;
+        contact.vars.lang = 'sw';
     }
     else {
-        service.vars.lang = 'en';
+        contact.vars.lang = 'en';
         contact.vars.English = true;
     }
     contact.save();

--- a/transaction-history/id-verification/index.js
+++ b/transaction-history/id-verification/index.js
@@ -8,7 +8,7 @@ module.exports = {
     handlerName: handlerName,
     getHandler: function (onIdValidated) {
         return function (input) {
-            var lang = state.vars.lang || service.vars.lang || project.vars.lang;
+            var lang = (contact && contact.vars.lang) || (state && state.vars.lang) || service.vars.lang || project.vars.lang;
             var translate = getTranslator(translations, lang);
             var client = roster.getClient(state.vars.account, state.vars.country);
             if(client.NationalId.slice(-4) !== input){

--- a/transaction-history/index.js
+++ b/transaction-history/index.js
@@ -8,7 +8,7 @@ var translations = require('./translations');
 
 module.exports = {
     registerHandlers: function () {
-        var language = (state && state.vars.lang) || service.vars.lang || project.vars.lang;
+        var language = (contact && contact.vars.lang) || (state && state.vars.lang) || service.vars.lang || project.vars.lang;
         var translate =  createTranslator(translations, language);
         state.vars.thPage = 1;
         function onIdVerified(client) { 

--- a/transaction-history/index.js
+++ b/transaction-history/index.js
@@ -40,7 +40,8 @@ module.exports = {
     start: function (account, country) {
         state.vars.account = account;
         state.vars.country = country;
-        var translate =  createTranslator(translations, project.vars.lang);
+        var language = (contact && contact.vars.lang) || (state && state.vars.lang) || service.vars.lang || project.vars.lang;
+        var translate =  createTranslator(translations, language);
         global.sayText(translate('last_4_national_id_prompt'));
         global.promptDigits(nidVerification.handlerName);
     }

--- a/transaction-history/list-transactions/index.js
+++ b/transaction-history/list-transactions/index.js
@@ -3,7 +3,7 @@ var translations = require('../translations');
 
 
 var listTransactions = function (transactionHistory, page, errorMessage) {
-    var language = (state && state.vars.lang) || service.vars.lang || project.vars.lang;
+    var language = (contact && contact.vars.lang) || (state && state.vars.lang) || service.vars.lang || project.vars.lang;
     var translate = createTranslator(translations, language);
     var offset = ((page || 1)-1) * 4;
     var to_show = transactionHistory.slice(offset, offset + 4);
@@ -24,7 +24,7 @@ var listTransactions = function (transactionHistory, page, errorMessage) {
 module.exports = {
     list: listTransactions,
     show: function (transaction) {
-        var language = (state && state.vars.lang) || service.vars.lang || project.vars.lang;
+        var language = (contact && contact.vars.lang) || (state && state.vars.lang) || service.vars.lang || project.vars.lang;
         var translate = createTranslator(translations, language);
         var RepaymentDate = transaction.RepaymentDate.split(' ')[0].replace( /\//g,'-');
         

--- a/transaction-history/translations.js
+++ b/transaction-history/translations.js
@@ -21,6 +21,7 @@ module.exports ={
     },
     'payment_detail': {
         'en': 'Payment ID: $RepaymentId\nDate Received: $RepaymentDate\nSeason: $Season\nAmount: $Amount RwF\nPaid from: $PaidFrom',
+        'en-ke': 'Payment ID: $RepaymentId\nDate Received: $RepaymentDate\nSeason: $Season\nAmount: $Amount KES\nPaid from: $PaidFrom',
         'ki': 'Nomero ndangagikorwa: $RepaymentId\nItariki yishyuriweho: $RepaymentDate\nIgihembwe: $Season\nAmafaranga: $Amount RwF\nYishyuwe avuye: $PaidFrom',
         'sw': 'Rekodi ya malipo: $RepaymentId\nTarehe ya malipo: $RepaymentDate\nMsimu: $Season\nIdadi ya malipo: $Amount KES\nMalipo kutoka simu nambari: $PaidFrom',
     },

--- a/transaction-history/translations.js
+++ b/transaction-history/translations.js
@@ -11,6 +11,7 @@ module.exports ={
     },
     'payment_list_item': {
         'en': '$option. $date - $amount RwF',
+        'en-ke': '$option. $date - $amount KES',
         'ki': '$option. $date - F$amount',
         'sw': '$option. $date - KES $amount'
     },

--- a/utils/translator/translator.js
+++ b/utils/translator/translator.js
@@ -11,7 +11,7 @@ function createTranslator(translations, defaultLanguage) {
     var translate = function (key, options, lang) {
         var entry = translations[key];
         if (entry === undefined) throw 'No Entry For "' + key + '"';
-        var template = entry[lang] ||lang && entry[lang.split('-')[0]] || entry[defaultLanguage];
+        var template = entry[lang] ||lang && entry[lang.split('-')[0]] || entry[defaultLanguage] || entry[defaultLanguage.split('-')[0]];
         if (template === undefined) throw 'No "' + lang + '" or "' + defaultLanguage + '" Translations For "' + key + '"';
         var text = template;
         if (options && Object.keys(options).length > 0) {

--- a/utils/translator/translator.js
+++ b/utils/translator/translator.js
@@ -11,7 +11,7 @@ function createTranslator(translations, defaultLanguage) {
     var translate = function (key, options, lang) {
         var entry = translations[key];
         if (entry === undefined) throw 'No Entry For "' + key + '"';
-        var template = entry[lang] || entry[defaultLanguage];
+        var template = entry[lang] ||lang && entry[lang.split('-')[0]] || entry[defaultLanguage];
         if (template === undefined) throw 'No "' + lang + '" or "' + defaultLanguage + '" Translations For "' + key + '"';
         var text = template;
         if (options && Object.keys(options).length > 0) {

--- a/utils/translator/translator.test.js
+++ b/utils/translator/translator.test.js
@@ -10,7 +10,8 @@ const exampleTranslations = {
         de: 'Guten tag'
     },
     'with-substitutions': {
-        en: 'Should I call you $firstName or $lastName',
+        en: 'Should I call you $firstName or $lastName?',
+        'en-ug': 'What should I call you? $firstName or $lastName.',
         sw: 'Ninapaswa Kukuita $firstName au $lastName',
     }
 };
@@ -43,6 +44,9 @@ describe('createTranslator', () => {
         it('should return the selected language translation', () => {
             expect(translate('simple', {}, 'sw')).toEqual(exampleTranslations.simple.sw);
         });
+        it('should return the languge translation if the locale translation is unavailable', () => {
+            expect(translate('simple', {}, 'sw-tz')).toEqual(exampleTranslations.simple.sw);
+        });
         it('should throw an error if there is no text matching the translations  ', () => {
             expect(() => {
                 translate('non-existent', {}, 'sw');
@@ -58,7 +62,12 @@ describe('createTranslator', () => {
         });
         it('should replace template placeholders with corresponding values from options', () => {
             expect(translate('with-substitutions', {$firstName: 'clark',$lastName: 'kent'}, 'en')).toEqual(
-                'Should I call you clark or kent'
+                'Should I call you clark or kent?'
+            );
+        });
+        it('should replace template placeholders with corresponding values from options in locale translations', () => {
+            expect(translate('with-substitutions', {$firstName: 'clark',$lastName: 'kent'}, 'en-ug')).toEqual(
+                'What should I call you? clark or kent.'
             );
         });
         

--- a/utils/translator/translator.test.js
+++ b/utils/translator/translator.test.js
@@ -44,8 +44,12 @@ describe('createTranslator', () => {
         it('should return the selected language translation', () => {
             expect(translate('simple', {}, 'sw')).toEqual(exampleTranslations.simple.sw);
         });
-        it('should return the languge translation if the locale translation is unavailable', () => {
+        it('should return the language translation if the locale translation is unavailable', () => {
             expect(translate('simple', {}, 'sw-tz')).toEqual(exampleTranslations.simple.sw);
+        });
+        it('should return the language translation if the default is a locale translation that is unavailable', () => {
+            translate = createTranslator(exampleTranslations,'sw-ug');
+            expect(translate('simple')).toEqual(exampleTranslations.simple.sw);
         });
         it('should throw an error if there is no text matching the translations  ', () => {
             expect(() => {


### PR DESCRIPTION
this adds transaction history support for Kenya.
It also adds support for locale based translations such that `en-ke` can fallback to `en` if not assigned.
Also adds some basic dev and production environments for Kenya as well
Test it using account `22846955` with national ID number ending with `6866` you can test it here: https://telerivet.com/p/0c6396c9/service/SV7a3fa65de30127c9/edit