### PR TITLE
Si 478 allow testing with dummy data

### DIFF
--- a/rw-legacy/extension-survey.js
+++ b/rw-legacy/extension-survey.js
@@ -443,8 +443,6 @@ inputHandlers['extension_questions'] = function(input){
             slack.log('Failed to get sector and cell from village Id: \n'+state.vars.village_id);
         }
         var table = project.initDataTableById('DTe1025290143442b5');
-        console.log(state.vars.village_id+state.vars.sector+state.vars.cell);
-        sayText(state.vars.village_id+state.vars.sector+state.vars.cell);
         var row = table.createRow({ 'vars': { 'national_id': state.vars.nationalId, 'first_name': state.vars.firstN, 'last_name': state.vars.lastN, 'gender' : state.vars.gender, 'phone_number': state.vars.phoneNumber,'village_id': state.vars.village_id,'Sector': state.vars.sector, 'Cell': state.vars.cell}});
         row.save();
         var rowAll = extensionTable.createRow({ 'vars': { 'national_id': state.vars.nationalId, 'not_eligible': 0}});

--- a/rw-legacy/extension-survey.js
+++ b/rw-legacy/extension-survey.js
@@ -443,6 +443,8 @@ inputHandlers['extension_questions'] = function(input){
             slack.log('Failed to get sector and cell from village Id: \n'+state.vars.village_id);
         }
         var table = project.initDataTableById('DTe1025290143442b5');
+        console.log(state.vars.village_id+state.vars.sector+state.vars.cell);
+        sayText(state.vars.village_id+state.vars.sector+state.vars.cell);
         var row = table.createRow({ 'vars': { 'national_id': state.vars.nationalId, 'first_name': state.vars.firstN, 'last_name': state.vars.lastN, 'gender' : state.vars.gender, 'phone_number': state.vars.phoneNumber,'village_id': state.vars.village_id,'Sector': state.vars.sector, 'Cell': state.vars.cell}});
         row.save();
         var rowAll = extensionTable.createRow({ 'vars': { 'national_id': state.vars.nationalId, 'not_eligible': 0}});

--- a/rw-legacy/lib/ext-resume-survey.js
+++ b/rw-legacy/lib/ext-resume-survey.js
@@ -13,7 +13,7 @@ function fetchSurveyState(phoneNumber) {
         remove: function () {
             row.delete();
         }
-    }
+    }   
 }
 /**
  * 
@@ -21,43 +21,49 @@ function fetchSurveyState(phoneNumber) {
  * @param {object} handlers 
  */
 function resumeSurvey(phoneNumber, handlers) {
-    var surveyState = fetchSurveyState(phoneNumber);
-    if (surveyState == null) {
-        return false;
-    }
-    if (surveyState.isExpired) {
-        surveyState.remove()
-        return false;
-    }
-    const savedState = surveyState.sessionInfo.state;
-    console.log('### fetched state: '+JSON.stringify(savedState));
-    
-    for (key in savedState) {
-        if (savedState.hasOwnProperty(key)) {
-            state.vars[key] = savedState[key];
+    if(!state.vars.testing){
+        var surveyState = fetchSurveyState(phoneNumber);
+        if (surveyState == null) {
+            return false;
         }
+        if (surveyState.isExpired) {
+            surveyState.remove()
+            return false;
+        }
+        const savedState = surveyState.sessionInfo.state;
+        console.log('### fetched state: '+JSON.stringify(savedState));
+        
+        for (key in savedState) {
+            if (savedState.hasOwnProperty(key)) {
+                state.vars[key] = savedState[key];
+            }
+        }
+        // TODO: call handler with input
+        const handler = surveyState.sessionInfo.handler;
+        const input = surveyState.sessionInfo.input;
+        if (handlers[handler]) {
+            console.log('#### Found hander');
+            handlers[handler](input);
+            return true;
+        }
+        console.log('#### Found no hander');
+        
+        return false;
+
     }
-    // TODO: call handler with input
-    const handler = surveyState.sessionInfo.handler;
-    const input = surveyState.sessionInfo.input;
-    if (handlers[handler]) {
-        console.log('#### Found hander');
-        handlers[handler](input);
-        return true;
-    }
-    console.log('#### Found no hander');
     
-    return false;
 };
 
 function clearSurveySession(phoneNumber) {
-    var survey_sessions = project.initDataTableById(service.vars.ExtSurveySessions);
-    var cursor = survey_sessions.queryRows({ 'vars': { 'phone_number': phoneNumber } });
-    if (!cursor.hasNext()) {
-        return
-    }
-    var row = cursor.next();
-    row.delete();
+    if(!state.vars.testing){
+        var survey_sessions = project.initDataTableById(service.vars.ExtSurveySessions);
+        var cursor = survey_sessions.queryRows({ 'vars': { 'phone_number': phoneNumber } });
+        if (!cursor.hasNext()) {
+            return
+        }
+        var row = cursor.next();
+        row.delete();
+    }  
 }
 
 /**
@@ -68,30 +74,34 @@ function clearSurveySession(phoneNumber) {
  * @param {string} input 
  */
 function saveSurveySession(phoneNumber, stateVars, handlerName, input) {
-    const sessionInfo = {
-        state: stateVars,
-        handler: handlerName,
-        input: input
-    }
-    var survey_sessions = project.initDataTableById(service.vars.ExtSurveySessions);
-    var cursor = survey_sessions.queryRows({ 'vars': { 'phone_number': phoneNumber } });
-    var row;
-    if (cursor.hasNext()) {
-        row = cursor.next();
-    } else {
-        row = survey_sessions.createRow({
-            from_number: phoneNumber,
-            vars: {}
-        });
-        console.log('created row');
-    }
-    console.log(sessionInfo);
+    if(!state.vars.testing){
+        const sessionInfo = {
+            state: stateVars,
+            handler: handlerName,
+            input: input
+        }
+        var survey_sessions = project.initDataTableById(service.vars.ExtSurveySessions);
+        var cursor = survey_sessions.queryRows({ 'vars': { 'phone_number': phoneNumber } });
+        var row;
+        if (cursor.hasNext()) {
+            row = cursor.next();
+        } else {
+            row = survey_sessions.createRow({
+                from_number: phoneNumber,
+                vars: {}
+            });
+            console.log('created row');
+        }
+        console.log(sessionInfo);
+    
+        row.vars.sessionInfo = JSON.stringify(sessionInfo);
+        row.vars.phone_number = phoneNumber
+        row.vars.handler = handlerName;
+        row.vars.input = input;
+        row.save();
 
-    row.vars.sessionInfo = JSON.stringify(sessionInfo);
-    row.vars.phone_number = phoneNumber
-    row.vars.handler = handlerName;
-    row.vars.input = input;
-    row.save()
+    }
+    
 }
 module.exports = {
     resume: resumeSurvey,


### PR DESCRIPTION
SI-478 allow testing with dummy village Ids(10000000 and 11111111) for the RW extension registration service

SI-477: add saving the village ID, Sector, and Cell.


Extension registration context: Appears as no1 on the menu, prompt for basic information, with questions afterward. All the answers should be yes except the second one for the farmer to be eligible and saved in the 'Extension Farmers' data table.

This PR makes sure that if 10000000 is entered as village ID, the resume session doesn't work in order to allow multiple people to use it in testing at the same time. It also saves additional information in the table for successful farmers. 

It can be tested here: https://telerivet.com/p/4bee87c0/service/SV80c59c2e64f4fe9d/edit