### PR TITLE
Modify receipt field calculations

### DIFF
--- a/duka-receipts/dukaReceipts.js
+++ b/duka-receipts/dukaReceipts.js
@@ -6,21 +6,22 @@
     }
     var getObjectKeys = require('./objectKeysFilter');
     var response = state.vars;
-    var unitPriceKeys = getObjectKeys(response, /^unitPrice?/);
     var rowPriceKeys = getObjectKeys(response, /^rowPrice?/);
+    var netRowPriceKeys = getObjectKeys(response, /^netRowPrice?/);
     var totalCost = 0;
     var productCost = 0;
     
-    unitPriceKeys.forEach(function(key){
-        var postFixNumber = key.match(/\d+/)[0];
-        var quantity = 'quantity' + postFixNumber;
-        totalCost = totalCost + (Number(response[key]) * Number(response[quantity])); 
+    rowPriceKeys.forEach(function(key){
+        totalCost = totalCost + Number(response[key]);
     });
     
-    rowPriceKeys.forEach(function(key){
+    netRowPriceKeys.forEach(function(key){
         productCost = productCost + Number(response[key]); 
     });
-    var vatCost = totalCost - productCost;
+
+    var total_cost = response.amount || totalCost;
+    
+    var vatCost = total_cost - productCost;
     var SMStext = 'Thank you for shopping at the OAF Duka! Date: ' + response.date + ' Invoice nro: ' + response.receipt + ' Product cost: KES ' + productCost + ' VAT: KES ' + vatCost.toFixed(2) + ' Total: KES ' + totalCost;
     var RouteIDPush = project.vars.route_push;
     var Label = project.getOrCreateLabel('Duka Receipt');

--- a/duka-receipts/dukaReceipts.test.js
+++ b/duka-receipts/dukaReceipts.test.js
@@ -2,30 +2,34 @@ describe('Mobile Money receipts', () => {
     beforeAll(() => {
         global.project.vars.route_push = 'ts7ajag2saGA82ya8';
         global.state = {vars: {
-            'date': '2020-07-07',
-            
-            'netRowPrice1': '373.91',
-            'netRowPrice2': '1346.10',
-            
-            'unitPrice1': '400.00',
-            'unitPrice2': '240.00',
-            
-            'quantity1': '1',
-            'quantity2': '6',
-            
-            'rowPrice1': '373.91',
-            'rowPrice2': '1346.10',
-            
-            'netUnitPrice1': '450.00',
-            'netUnitPrice2': '260.00',
-            
-            'name1': 'Foliar fertilizer [Stock]',
-            'name2': 'Crop Storage; PICS Storage Bag [Stock]',
-            
-            
-            'receipt': '34002858',
-            'phone': '0721415321',
-            'amount': 1720.01,
+            'date': '2020-07-26',
+            'netRowPrice1': '140.36',
+            'netRowPrice2': '122.81',
+            'netRowPrice3': '175.44',
+            'netRowPrice4': '100.00',
+            'unitPrice3': '200.00',
+            'unitPrice4': '100.00',
+            'unitPrice1': '80.01',
+            'unitPrice2': '140.00',
+            'rowPrice3': '200.00',
+            'rowPrice4': '100.00',
+            'rowPrice1': '160.01',
+            'rowPrice2': '140.00',
+            'netUnitPrice4': '100.00',
+            'netUnitPrice3': '175.44',
+            'netUnitPrice2': '122.81',
+            'netUnitPrice1': '70.18',
+            'amount': 600,
+            'quantity1': '2',
+            'quantity2': '1',
+            'quantity3': '1',
+            'quantity4': '1',
+            'name4': 'Mavuno; Garden Leafy; NPK 20:10:18 +TE; 1 KG Bag [Stock]',
+            'name3': 'Vegetable; Red Creole Onions, 25 GM Unit [Stock]',
+            'name2': 'Vegetable; Sukuma; 50 GM Unit [Stock]',
+            'name1': 'Vegetable; Spinach (Swiss Chard); 25g Packet [STOCK]',
+            'phone': '254715831743 ',
+            'receipt': '54003657',
         }
         };
         global.contact.phone_number = '0750475911';
@@ -36,7 +40,7 @@ describe('Mobile Money receipts', () => {
     it('should send an updated receips message', () => {
         jest.spyOn(project, 'getOrCreateLabel').mockReturnValue({id: 1});
         require('./dukaReceipts');
-        expect(project.sendMessage).toHaveBeenCalledWith({'content': 'Thank you for shopping at the OAF Duka! Date: 2020-07-07 Invoice nro: 34002858 Product cost: KES 1720.01 VAT: KES 119.99 Total: KES 1840',
+        expect(project.sendMessage).toHaveBeenCalledWith({'content': 'Thank you for shopping at the OAF Duka! Date: 2020-07-26 Invoice nro: 54003657 Product cost: KES 538.61 VAT: KES 61.39 Total: KES 600.01',
             'label_ids': [1], 
             'route_id': 'ts7ajag2saGA82ya8',
             'to_number': '0750475911'});
@@ -49,6 +53,10 @@ describe('Mobile Money receipts', () => {
         require('./dukaReceipts');
         expect(global.sendEmail).toHaveBeenCalledWith('user@tester.com', 
             'Testing email', 
-            '{"date":"2020-07-07","netRowPrice1":"373.91","netRowPrice2":"1346.10","unitPrice1":"400.00","unitPrice2":"240.00","quantity1":"1","quantity2":"6","rowPrice1":"373.91","rowPrice2":"1346.10","netUnitPrice1":"450.00","netUnitPrice2":"260.00","name1":"Foliar fertilizer [Stock]","name2":"Crop Storage; PICS Storage Bag [Stock]","receipt":"34002858","phone":"0721415321","amount":1720.01,"email":"user@tester.com"}');
+            '{"date":"2020-07-26","netRowPrice1":"140.36","netRowPrice2":"122.81","netRowPrice3":"175.44","netRowPrice4":"100.00","unitPrice3":"200.00",' + 
+            '"unitPrice4":"100.00","unitPrice1":"80.01","unitPrice2":"140.00","rowPrice3":"200.00","rowPrice4":"100.00","rowPrice1":"160.01","rowPrice2":"140.00",' + 
+            '"netUnitPrice4":"100.00","netUnitPrice3":"175.44","netUnitPrice2":"122.81","netUnitPrice1":"70.18","amount":600,"quantity1":"2","quantity2":"1",' + 
+            '"quantity3":"1","quantity4":"1","name4":"Mavuno; Garden Leafy; NPK 20:10:18 +TE; 1 KG Bag [Stock]","name3":"Vegetable; Red Creole Onions, 25 GM Unit [Stock]",' + 
+            '"name2":"Vegetable; Sukuma; 50 GM Unit [Stock]","name1":"Vegetable; Spinach (Swiss Chard); 25g Packet [STOCK]","phone":"254715831743 ","receipt":"54003657","email":"user@tester.com"}');
     });
 });


### PR DESCRIPTION
The calculations mentioned in the past ticket were slightly off. After confirming with the stakeholder, they should be updated to:

Total cost = amount = sum of all **row prices** = eg: 220.05

Product cost = sum of all **net row prices** for every product = eg: 193.03

VAT = total cost - product cost = 220.05 - 193.03 = 27.02

Test from [Telerivet](https://telerivet.com/p/070b4dfe/services?mode=d&sort=name&f[status]=0&f[trigger_id]=2)