### PR TITLE
Ser 26 update pshops to support new vendor

### DIFF
--- a/rw-legacy/lib/psh-check-account.js
+++ b/rw-legacy/lib/psh-check-account.js
@@ -7,15 +7,18 @@
 module.exports = function(accnum){
     // some code to be able to use Roster API
     var client = null;
-    var api = require('ext/Roster_v1_2_0/api'); //roster. todo make more general
-    api.dataTableAttach('ExternalApis');
+    var api = require('../lib/roster/api'); //roster. occasionally will need update
+    api.loadURLAndAPIKey();
+    //var api = require('ext/Roster_v1_2_0/api'); //roster. todo make more general
+    //api.dataTableAttach('ExternalApis');
     var country = project.vars.country; 
     api.verbose = true;
-    api.dataTableAttach('ExternalApis'); //todo: make more general
+    //api.dataTableAttach('ExternalApis'); //todo: make more general
 
     require('./account-verify')(accnum); // run account number through core account verify function
     console.log(state.vars.client_district);
     if(state.vars.client_district === 'RRT P-Shops'){
+        
         var client = api.getClient(accnum);
         state.vars.client_json = JSON.stringify(client);
         state.vars.TotalCredit = client.BalanceHistory[0].TotalCredit;

--- a/rw-legacy/lib/psh-reg-check.js
+++ b/rw-legacy/lib/psh-reg-check.js
@@ -24,18 +24,22 @@ module.exports = function(accnum){
         var Activationtable = project.getOrCreateDataTable(service.vars.activation_code_table);
         // if the serial number is unlocked, retrieve the the relevant activation code
         if (Serial.vars.unlock == "Yes"){
+            console.log('unlock is:' + Serial.vars.unlock);
             state.vars.unlock = true;
             var unlockVars = {
                 'activated': 'Yes',
                 'unlock': 'Yes',
                 'serialnumber': state.vars.serial_no,
-                'product_type': {'ne': 'biolite'}
             };
-            // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
-            if(Serial.vars.product_type == 'biolite'){
-                unlockVars['product_type'] = 'biolite';
+            // If the the product type is not null check if it is biolite
+            if(Serial.vars.product_type != null){
+                unlockVars['product_type'] = {'ne': 'biolite'};
+                // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+                if(Serial.vars.product_type == 'biolite'){
+                    unlockVars['product_type'] = 'biolite';
+                }
             }
-            console.log('unlock vars ' + unlockVars);
+            console.log('unlock vars ' + JSON.stringify(unlockVars));
             ActList = Activationtable.queryRows({
                 vars: unlockVars,
             });
@@ -47,8 +51,9 @@ module.exports = function(accnum){
                 return true;
             }
             else{
-                admin_alert('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes', 'marisa');
-                slack.log('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes');
+                //admin_alert('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes', 'marisa');
+                //slack.log('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes');
+                console.log('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes');
                 return false;
             }
         }
@@ -60,15 +65,25 @@ module.exports = function(accnum){
             var activationVars= {
                 'activated': "Yes",
                 'serialnumber': state.vars.serial_no,
-                'product_type': {'ne': 'biolite'}
             };
-            // If the product type is biolite in the serial tabe, we look for matching serial number with biolite type 
-            if(Serial.vars.product_type == 'biolite'){
-                activationVars['product_type'] = 'biolite';
+            // If the the product type is not nul check if it s biolite
+            if(Serial.vars.product_type != null){
+                activationVars['product_type'] = {'ne': 'biolite'};
+                // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+                if(Serial.vars.product_type == 'biolite'){
+                    activationVars['product_type'] = 'biolite';
+                }
             }
+            console.log(JSON.stringify(activationVars));
             ActList = Activationtable.queryRows({
                 vars: activationVars,
             });
+            if(ActList.count() == 0){
+                //admin_alert('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes', 'marisa');
+                //slack.log('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes');
+                console.log('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes');
+                return false;
+            }
             // save the client's number of codes used
             Serial.vars.numbercodes = ActList.count();
             Serial.save();

--- a/rw-legacy/lib/psh-reg-check.js
+++ b/rw-legacy/lib/psh-reg-check.js
@@ -22,16 +22,22 @@ module.exports = function(accnum){
         var Serial = ListRows.next();
         state.vars.serial_no = Serial.vars.serialnumber;
         var Activationtable = project.getOrCreateDataTable(service.vars.activation_code_table);
-
         // if the serial number is unlocked, retrieve the the relevant activation code
         if (Serial.vars.unlock == "Yes"){
             state.vars.unlock = true;
+            var unlockVars = {
+                'activated': 'Yes',
+                'unlock': 'Yes',
+                'serialnumber': state.vars.serial_no,
+                'product_type': {'ne': 'biolite'}
+            };
+            // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+            if(Serial.vars.product_type == 'biolite'){
+                unlockVars['product_type'] = 'biolite';
+            }
+            console.log('unlock vars ' + unlockVars);
             ActList = Activationtable.queryRows({
-                vars: {
-                    'activated': "Yes",
-                    'unlock': "Yes",
-                    'serialnumber': state.vars.serial_no
-                },
+                vars: unlockVars,
             });
             
             // if the serial number is in the table, retrieve the corresponding activation code; else send alert to admin
@@ -48,14 +54,20 @@ module.exports = function(accnum){
         }
         else{
             console.log('About to get the latest activation code');
-        // Get latest activation code
+            // Get latest activation code
             state.vars.unlock = false;
             var Activationtable = project.getOrCreateDataTable(service.vars.activation_code_table);
+            var activationVars= {
+                'activated': "Yes",
+                'serialnumber': state.vars.serial_no,
+                'product_type': {'ne': 'biolite'}
+            };
+            // If the product type is biolite in the serial tabe, we look for matching serial number with biolite type 
+            if(Serial.vars.product_type == 'biolite'){
+                activationVars['product_type'] = 'biolite';
+            }
             ActList = Activationtable.queryRows({
-                vars: {
-                    'activated': "Yes",
-                    'serialnumber': state.vars.serial_no
-                },
+                vars: activationVars,
             });
             // save the client's number of codes used
             Serial.vars.numbercodes = ActList.count();

--- a/rw-legacy/lib/psh-reg-check.js
+++ b/rw-legacy/lib/psh-reg-check.js
@@ -7,7 +7,7 @@
 module.exports = function(accnum){
     // load relevant functions and data tables
     var admin_alert = require('./admin-alert');
-    var table = project.getOrCreateDataTable("SerialNumberTable");
+    var table = project.getOrCreateDataTable(service.vars.serial_number_table);
     state.vars.duplicate = false; 
 
     // retrieve rows where account number in table corresponds to input account number
@@ -20,7 +20,7 @@ module.exports = function(accnum){
     if(ListRows.count() === 1){
         var Serial = ListRows.next();
         state.vars.serial_no = Serial.vars.serialnumber;
-        var Activationtable = project.getOrCreateDataTable("ActivationCodes");
+        var Activationtable = project.getOrCreateDataTable(service.vars.activation_code_table);
 
         // if the serial number is unlocked, retrieve the the relevant activation code
         if (Serial.vars.unlock == "Yes"){
@@ -48,7 +48,7 @@ module.exports = function(accnum){
             console.log('About to get the latest activation code');
         // Get latest activation code
             state.vars.unlock = false;
-            var Activationtable = project.getOrCreateDataTable("ActivationCodes");
+            var Activationtable = project.getOrCreateDataTable(service.vars.activation_code_table);
             ActList = Activationtable.queryRows({
                 vars: {
                     'activated': "Yes",

--- a/rw-legacy/lib/psh-reg-check.js
+++ b/rw-legacy/lib/psh-reg-check.js
@@ -7,6 +7,7 @@
 module.exports = function(accnum){
     // load relevant functions and data tables
     var admin_alert = require('./admin-alert');
+    var slack = require('../../slack-logger/index');
     var table = project.getOrCreateDataTable(service.vars.serial_number_table);
     state.vars.duplicate = false; 
 
@@ -41,6 +42,7 @@ module.exports = function(accnum){
             }
             else{
                 admin_alert('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes', 'marisa');
+                slack.log('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes');
                 return false;
             }
         }

--- a/rw-legacy/lib/psh-renew-code.js
+++ b/rw-legacy/lib/psh-renew-code.js
@@ -47,11 +47,15 @@ module.exports = function(accnum, serial_no){
     // Taking into consideration the biolite product type
     var activationCodeVars = { 
         'serialnumber' : serial_no,
-        'product_type': {'ne': 'biolite'},
         'dateactivated' : {exists : 1}
     }
-    if(serial.vars.product_type == 'biolite'){
-        activationCodeVars['product_type'] = 'biolite'
+    // If the the product type is not nul check if it s biolite
+    if(serial.vars.product_type != null){
+        activationCodeVars['product_type'] = {'ne': 'biolite'};
+        // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+        if(serial.vars.product_type == 'biolite'){
+            activationCodeVars['product_type'] = 'biolite';
+        }
     }
     // the section below checks how long ago the past activation code was given
     // initialize variables
@@ -117,11 +121,15 @@ module.exports = function(accnum, serial_no){
         var listActVars = {
             'serialnumber': serial_no,
             'type': "Unlock",
-            'product_type': {'ne': 'biolite'},
             'activated': "No"
         }
-        if(serial.vars.product_type == 'biolite'){
-            listActVars['product_type'] = 'biolite';
+        // If the the product type is not nul check if it s biolite
+        if(serial.vars.product_type != null){
+            listActVars['product_type'] = {'ne': 'biolite'};
+            // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+            if(serial.vars.product_type == 'biolite'){
+                listActVars['product_type'] = 'biolite';
+            }
         }
         var ListAct = act_table.queryRows({
             vars: listActVars
@@ -132,11 +140,14 @@ module.exports = function(accnum, serial_no){
                 'serialnumber': serial_no,
                 'type': "Unlock",
                 'activated': {exists : 0},
-                'product_type': {'ne': 'biolite'}
             }
-        
-            if(serial.vars.product_type == 'biolite'){
-                listActVars['product_type'] = 'biolite';
+            // If the the product type is not nul check if it s biolite
+            if(serial.vars.product_type != null){
+                listActVars['product_type'] = {'ne': 'biolite'};
+                // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+                if(serial.vars.product_type == 'biolite'){
+                    listActVars['product_type'] = 'biolite';
+                }
             }
             var ListAct = act_table.queryRows({
                 vars: listActVars
@@ -153,10 +164,14 @@ module.exports = function(accnum, serial_no){
             'serialnumber': serial_no,
             'type': "Activation",
             'activated': "No",
-            'product_type': {'ne': 'biolite'}
         }
-        if(serial.vars.product_type == 'biolite'){
-            listActVars['product_type'] = 'biolite';
+        // If the the product type is not nul check if it s biolite
+        if(serial.vars.product_type != null){
+            listActVars['product_type'] = {'ne': 'biolite'};
+            // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+            if(serial.vars.product_type == 'biolite'){
+                listActVars['product_type'] = 'biolite';
+            }
         }
         var ListAct = act_table.queryRows({
             vars: listActVars
@@ -168,11 +183,15 @@ module.exports = function(accnum, serial_no){
                 'serialnumber': serial_no,
                 'type': "Activation",
                 'activated': {exists : 0},
-                'product_type': {'ne': 'biolite'}
             }
-            if(serial.vars.product_type == 'biolite'){
-                listActVars['product_type'] = 'biolite';
-            }    
+            // If the the product type is not nul check if it s biolite
+            if(serial.vars.product_type != null){
+                listActVars['product_type'] = {'ne': 'biolite'};
+                // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+                if(serial.vars.product_type == 'biolite'){
+                    listActVars['product_type'] = 'biolite';
+                }
+            }   
             var ListAct = act_table.queryRows({
                 vars: listActVars
             });

--- a/rw-legacy/lib/psh-renew-code.js
+++ b/rw-legacy/lib/psh-renew-code.js
@@ -44,11 +44,19 @@ module.exports = function(accnum, serial_no){
     var months_between = current_month - month_reg;
     console.log("MonthsBetween: " + months_between + "\n MaxBalance: " + MaxBalance + "\n Balance: " + state.vars.Balance);
 
+    // Taking into consideration the biolite product type
+    var activationCodeVars = { 
+        'serialnumber' : serial_no,
+        'product_type': {'ne': 'biolite'},
+        'dateactivated' : {exists : 1}
+    }
+    if(serial.vars.product_type == 'biolite'){
+        activationCodeVars['product_type'] = 'biolite'
+    }
     // the section below checks how long ago the past activation code was given
     // initialize variables
     var act_pointer = act_table.queryRows({
-        vars: { 'serialnumber' : serial_no,
-                'dateactivated' : {exists : 1}}
+        vars: activationCodeVars
     });
     var month_active = 0;
     var month_check = 0;
@@ -104,18 +112,34 @@ module.exports = function(accnum, serial_no){
     // if balance is zero and months between is larger than one, client has unlocked product
     if(state.vars.Balance === 0 && months_between > 1){
         state.vars.NewCodeStatus = "Unlock";
+
+        // Taking into consideration the biolite product type
+        var listActVars = {
+            'serialnumber': serial_no,
+            'type': "Unlock",
+            'product_type': {'ne': 'biolite'},
+            'activated': "No"
+        }
+        if(serial.vars.product_type == 'biolite'){
+            listActVars['product_type'] = 'biolite';
+        }
         var ListAct = act_table.queryRows({
-            vars: {'serialnumber': serial_no,
-                    'type': "Unlock",
-                    'activated': "No"
-            }
+            vars: listActVars
         });
         if(ListAct.count() < 1){
+            // Taking into consideration the biolite product type
+            var listActVars ={
+                'serialnumber': serial_no,
+                'type': "Unlock",
+                'activated': {exists : 0},
+                'product_type': {'ne': 'biolite'}
+            }
+        
+            if(serial.vars.product_type == 'biolite'){
+                listActVars['product_type'] = 'biolite';
+            }
             var ListAct = act_table.queryRows({
-                vars: {'serialnumber': serial_no,
-                        'type': "Unlock",
-                        'activated': {exists : 0}
-                }
+                vars: listActVars
             });
         }         
         ListAct.limit(1); // replace with error flags
@@ -124,19 +148,33 @@ module.exports = function(accnum, serial_no){
     }
     else if(state.vars.Balance <= MaxBalance && month_valid){
         state.vars.NewCodeStatus = "Yes";
+        // Taking into consideration the biolite product type
+        var listActVars = {
+            'serialnumber': serial_no,
+            'type': "Activation",
+            'activated': "No",
+            'product_type': {'ne': 'biolite'}
+        }
+        if(serial.vars.product_type == 'biolite'){
+            listActVars['product_type'] = 'biolite';
+        }
         var ListAct = act_table.queryRows({
-            vars: {'serialnumber': serial_no,
-                    'type': "Activation",
-                    'activated': "No"
-            }
+            vars: listActVars
         });  
         console.log('rows in listact: ' + ListAct.count());
         if(ListAct.count() < 1){
+            // Taking into consideration the biolite product type
+            var listActVars = {
+                'serialnumber': serial_no,
+                'type': "Activation",
+                'activated': {exists : 0},
+                'product_type': {'ne': 'biolite'}
+            }
+            if(serial.vars.product_type == 'biolite'){
+                listActVars['product_type'] = 'biolite';
+            }    
             var ListAct = act_table.queryRows({
-                vars: {'serialnumber': serial_no,
-                        'type': "Activation",
-                        'activated': {exists : 0}
-                }
+                vars: listActVars
             });
         }
         ListAct.limit(1); 

--- a/rw-legacy/lib/psh-renew-code.js
+++ b/rw-legacy/lib/psh-renew-code.js
@@ -6,7 +6,7 @@
 
 module.exports = function(accnum, serial_no){
     // load relevant data tables from Telerivet
-    var admin_alert = require('./admin-alert');
+    var admin_alert = require('./admin-alert'); 
     var serial_table = project.getOrCreateDataTable(service.vars.serial_number_table);
     var act_table = project.getOrCreateDataTable(service.vars.activation_code_table);
 

--- a/rw-legacy/lib/psh-renew-code.js
+++ b/rw-legacy/lib/psh-renew-code.js
@@ -7,8 +7,8 @@
 module.exports = function(accnum, serial_no){
     // load relevant data tables from Telerivet
     var admin_alert = require('./admin-alert');
-    var serial_table = project.getOrCreateDataTable("SerialNumberTable");
-    var act_table = project.getOrCreateDataTable("ActivationCodes");
+    var serial_table = project.getOrCreateDataTable(service.vars.serial_number_table);
+    var act_table = project.getOrCreateDataTable(service.vars.activation_code_table);
 
     // retrieve the row in the serial table with the relevant account number
     var serial_pointer = serial_table.queryRows({

--- a/rw-legacy/lib/psh-serial-verify.js
+++ b/rw-legacy/lib/psh-serial-verify.js
@@ -7,7 +7,7 @@
 module.exports = function(accnum, serial_no){
     // retrieve necssary tables and modules
     var admin_alert = require('./admin-alert');
-    var SerialTable = project.getOrCreateDataTable("SerialNumberTable");
+    var SerialTable =  project.getOrCreateDataTable(service.vars.serial_number_table);
 
     // save as variable the row from the serial table where the entered serial number matches
     if(state.vars.duplicate){
@@ -32,7 +32,7 @@ module.exports = function(accnum, serial_no){
         Serial.save(); 
         
         // retrieve one unused activation code for this serial number
-        var ActTable = project.getOrCreateDataTable("ActivationCodes");
+        var ActTable = project.getOrCreateDataTable(service.vars.activation_code_table);
         ListAct = ActTable.queryRows({
             vars: {'serialnumber': serial_no,
                     'type': "Activation",

--- a/rw-legacy/lib/psh-serial-verify.js
+++ b/rw-legacy/lib/psh-serial-verify.js
@@ -31,19 +31,21 @@ module.exports = function(accnum, serial_no){
         Serial.vars.accountnumber = accnum; 
         Serial.vars.historic_credit = state.vars.TotalCredit - state.vars.Balance;
         Serial.vars.dateregistered = new Date().toString();
+        Serial.vars.product_type = 'biolite';
         Serial.save(); 
         
         // retrieve one unused activation code for this serial number
         var ActTable = project.getOrCreateDataTable(service.vars.activation_code_table);
         ListAct = ActTable.queryRows({
             vars: {'serialnumber': serial_no,
-                    'type': "Activation",
-                    'activated': "No"
+                'type': 'Activation',
+                'activated': 'No',
+                'product_type': 'biolite'   // because only biolite products are being sold now 
             }
         });
         if(ListAct.count() < 1){
-            admin_alert('No codes remaining for SHS product with serial number: ' + serial_no, 'No remaining serial numbers', 'marisa');
-            slack.log('No codes remaining for SHS product with serial number: ' + serial_no, 'No remaining serial numbers');
+            admin_alert('No codes remaining for Biolite product with serial number: ' + serial_no, 'No remaining serial numbers', 'marisa');
+            slack.log('No codes remaining for Biolite product with serial number: ' + serial_no, 'No remaining serial numbers');
         }
         else{
             ListAct.limit(1);

--- a/rw-legacy/lib/psh-serial-verify.js
+++ b/rw-legacy/lib/psh-serial-verify.js
@@ -44,24 +44,26 @@ module.exports = function(accnum, serial_no){
             }
         });
         if(ListAct.count() < 1){
-            admin_alert('No codes remaining for Biolite product with serial number: ' + serial_no, 'No remaining serial numbers', 'marisa');
-            slack.log('No codes remaining for Biolite product with serial number: ' + serial_no, 'No remaining serial numbers');
+            //admin_alert('No codes remaining for Biolite product with serial number: ' + serial_no, 'No remaining serial numbers', 'marisa');
+            //slack.log('No codes remaining for Biolite product with serial number: ' + serial_no);
+            console.log('No codes remaining for Biolite product with serial number: ' + serial_no, 'No remaining serial numbers');
+            return false;
         }
         else{
             ListAct.limit(1);
+            var Act = ListAct.next();
+            state.vars.ActCode = Act.vars.code;
+            Act.vars.activated = "Yes";
+            Act.vars.dateactivated = new Date().toString();
+            Act.save();
         }
-        
         // update the activation table to say that this code has been used
-        var Act = ListAct.next();
-        state.vars.ActCode = Act.vars.code;
-        Act.vars.activated = "Yes";
-        Act.vars.dateactivated = new Date().toString();
-        Act.save();
     }
     // if there are more than one rows with the input serial number, flag an error
     else if(ListRows.count() > 1){
         admin_alert('duplicate serial numbers in PSHOPs database sn: ' + serial_no, 'Duplicate Serial Numbers in TR DB', 'marisa');
-        slack.log('duplicate serial numbers in PSHOPs database sn: ' + serial_no, 'Duplicate Serial Numbers in TR DB');
+        slack.log('duplicate serial numbers in PSHOPs database sn: ' + serial_no);
+        console.log('duplicate serial numbers in PSHOPs database sn: ' + serial_no, 'Duplicate Serial Numbers in TR DB');
         return false;
     }
     // if there are zero rows in the table with the serial number, return false

--- a/rw-legacy/lib/psh-serial-verify.js
+++ b/rw-legacy/lib/psh-serial-verify.js
@@ -4,9 +4,11 @@
     Status: complete
 */
 
+
 module.exports = function(accnum, serial_no){
     // retrieve necssary tables and modules
     var admin_alert = require('./admin-alert');
+    var slack = require('../../slack-logger/index');
     var SerialTable =  project.getOrCreateDataTable(service.vars.serial_number_table);
 
     // save as variable the row from the serial table where the entered serial number matches
@@ -41,6 +43,7 @@ module.exports = function(accnum, serial_no){
         });
         if(ListAct.count() < 1){
             admin_alert('No codes remaining for SHS product with serial number: ' + serial_no, 'No remaining serial numbers', 'marisa');
+            slack.log('No codes remaining for SHS product with serial number: ' + serial_no, 'No remaining serial numbers');
         }
         else{
             ListAct.limit(1);
@@ -56,6 +59,7 @@ module.exports = function(accnum, serial_no){
     // if there are more than one rows with the input serial number, flag an error
     else if(ListRows.count() > 1){
         admin_alert('duplicate serial numbers in PSHOPs database sn: ' + serial_no, 'Duplicate Serial Numbers in TR DB', 'marisa');
+        slack.log('duplicate serial numbers in PSHOPs database sn: ' + serial_no, 'Duplicate Serial Numbers in TR DB');
         return false;
     }
     // if there are zero rows in the table with the serial number, return false

--- a/rw-legacy/lib/utils/message-translations.js
+++ b/rw-legacy/lib/utils/message-translations.js
@@ -743,8 +743,69 @@ module.exports = {
             "en":"Number of farmers" ,
             "ki": "Umubare w'abahinzi"
         
-    },"maize_number":{
+    },
+    "maize_number":{
         "en": "Quantity of this unshelled maize to sell in bags (use big bags of 100kg)",
         "ki": "Imifuka y'ibigori bidahunguye ugurisha(hakoreshwa umufuka munini w'ibiro 100)"
+    },
+    "pshops_main_splash":{
+        "en": "Welcome to the PShop Client portal. Please enter your Account Number",
+        "ki": "Murakaza neza ku iduka. Injizamo konti yawe y'umuhinzi",
+    },
+    "incorrect_account_number":{
+        "en": "Incorrect input. Please enter your Account Number",
+        "ki": "Winjije umubare utariwo. Ongera winjze umubare wa konti yawe ukoresha wishyura iduka",
+    },
+    "pshop_main_menu":{
+        "en": "Welcome $NAME ~B1 - To check balance ~B2 - Solar Codes",
+        "ki": "Murakaza neza $NAME ~B1. Kureba uko ubwishyu buhagaze ~B2. Kodi y'itara",
+    },
+    "main_message":{
+        "en": "Paid: $REPAY ~BTotal credit: $CREDIT ~BRemaining: $BALANCE ~B1 - Back to main menu",
+        "ki": "Ayishyuwe: $REPAY ~BIdeni ryose: $CREDIT ~BIdeni risigaye: $BALANCE ~B1 - Subira inyuma",
+    },
+    "solar_unlocked":{
+        "en": "You registered Serial $SERIAL ~BUnlock code: $ACTCODE ~B99 - Back to menu",
+        "ki": "Umubare uranga itara ryawe ni: $SERIAL ~BKodi yawe ya burundu ni: $ACTCODE ~B99. Subira inyuma",
+    },
+    "solar_locked":{
+        "en": "You registered Serial $SERIAL ~BLast code: $ACTCODE ~B1- New code ~B99 - Back to menu",
+        "ki": "Umubare uranga itara ryawe ni: $SERIAL ~BKodi uheruka kubona ni: $ACTCODE ~B1. Kodi nshya ~B99. Subira inyuma",
+    },
+    "solar_nonreg":{
+        "en": "You have not registered an SHS. Enter your Serial Number to register ~B99 - Back to menu",
+        "ki": "Ntabwo wandikishije itara ryawe. Injizamo umubare uranga itara kugirango uryandikishe ~B99. Subira inyuma",
+    },
+    "insufficient_funds":{
+        "en": "You have not paid enough to request your new code ~BTo the next code: $REMAIN_BAL ~BTo unlock: $BALANCE ~B1 - Back to main",
+        "ki": "Ubwishyu bwawe ntibuhagije. Ubusigaye ngo ubone kodi ~BNshya: $REMAIN_BAL ~BYa burundu: $BALANCE ~B1. Subira ahabanza",
+    },
+    "unlock_success":{
+        "en": "You have successfully unlocked your SHS! Your unlock code is: $ACTCODE ~B1 - Back to main",
+        "ki": "Warangije kwishyura neza itara ryawe! Kodi ya burundu ni: $ACTCODE ~B1. Subira ahabanza",
+    },
+    "activation_code":{
+        "en": "Your new activation code is: $ACTCODE ~B1 - Back to main",
+        "ki": "Kodi yawe nshya ni: $ACTCODE ~B1. Subira ahabanza",
+    },
+    "reg_success":{
+        "en": "You have registered. Your activation code is $ACTCODE ~B99 - Back to menu",
+        "ki": "Kwandikisha itara ryawe byagenze neza. Kodi yo gucana itara ryawe ni: $ACTCODE ~B99. Subira inyuma",
+    },
+    "already_reg":{
+        "en": "Serial number already registered please try again ~B99 - Back to menu",
+        "ki": "Umubare uranga itara winjije warafashwe. Ongera ugerageze ~B99. Subira inyuma",
+    },
+    "serial_not_found":{
+        "en": "This serial number is not found please try again ~B99 - Back to menu",
+        "ki": "Umubare uranga itara ushyizemo ntubaho. Ongera ugerageze ~B99. Subira inyuma",
+    },
+    "client_alert":{
+        "en": "An error has occurred and has been reported to our technical team.",
+        "ki": "Habayemo ikibazo kandi cyoherejwe ku ikipe ishinzwe kugikemura.",
+    },
+    "invalid_input":{
+        "en": "Incorrect input. ~B1 - To check balance ~B2 - Solar Codes",
+        "ki": "Winjije umubare utariwo. ~B1. Kureba uko ubwishyu buhagaze ~B2. Kodi y'itara",
     }
 }

--- a/rw-legacy/pshops.js
+++ b/rw-legacy/pshops.js
@@ -18,12 +18,12 @@ if(service.vars.env === 'prod' || service.vars.env === 'dev'){
 }
 if(env === 'prod'){
     service.vars.activation_code_table = 'ActivationCodes';
-    service.vars.serial_number_table = 'SeriaNumberTable';
+    service.vars.serial_number_table = 'SerialNumberTable';
     service.vars.pShop_main_menu = 'pshop_main_menu';
 }
 else{
     service.vars.activation_code_table = 'dev_ActivationCodes';
-    service.vars.serial_number_table = 'dev_SeriaNumberTable';
+    service.vars.serial_number_table = 'dev_SerialNumberTable';
     service.vars.pShop_main_menu = 'dev_pshop_main_menu';
 }
 

--- a/rw-legacy/pshops.js
+++ b/rw-legacy/pshops.js
@@ -3,6 +3,29 @@
     Purpose: OAF RW PShops Client Portal; allows clients to register, get new codes, and check balance for SHS products
     Status: complete
 */
+var defaultEnvironment;
+if(service.active){
+    defaultEnvironment = 'prod'
+}else{
+    defaultEnvironment = 'dev'
+}
+
+var env;
+if(service.vars.env === 'prod' || service.vars.env === 'dev'){
+    env = service.vars.env;
+}else{
+    env = defaultEnvironment;
+}
+if(env === 'prod'){
+    service.vars.activation_code_table = 'ActivationCodes';
+    service.vars.serial_number_table = 'SeriaNumberTable';
+    service.vars.pShop_main_menu = 'pshop_main_menu';
+}
+else{
+    service.vars.activation_code_table = 'dev_ActivationCodes';
+    service.vars.serial_number_table = 'dev_SeriaNumberTable';
+    service.vars.pShop_main_menu = 'dev_pshop_main_menu';
+}
  
 // load in necessary functions
 var msgs = require('./lib/msg-retrieve'); // global message handler
@@ -20,6 +43,9 @@ const max_digits_for_account_number = parseInt(settings_table.queryRows({'vars' 
 const max_digits = parseInt(settings_table.queryRows({'vars' : {'settings' : 'max_digits'}}).next().vars.value);
 const timeout_length = 180; // this doesn't appear to work. data type error?
 const lang = project.vars.cor_lang;
+var menuTable = service.vars.pShop_main_menu;
+var activation_code_table = service.vars.activation_code_table;
+var serial_number_table = service.vars.serial_number_table ;
 
 // display welcome message and prompt user to enter account number
 global.main = function() {
@@ -35,7 +61,7 @@ addInputHandler('account_number_splash', function(accnum){
     // if account number is valid, save it as a state variable and display main menu
         if(check_account_no(accnum)){ 
             state.vars.accnum = accnum;
-            var menu = populate_menu('pshop_main_menu', lang);
+            var menu = populate_menu(menuTable, lang);
             state.vars.current_menu_str = menu;
             sayText(msgs('pshop_main_menu', {'$NAME' : state.vars.client_name}, lang));
             promptDigits('pshop_menu_select', { 'submitOnHash' : false,
@@ -64,7 +90,7 @@ addInputHandler('pshop_menu_select', function(input){
     // clean input and save current step as a variable
     input = String(input.replace(/\D/g,''));
     state.vars.current_step = 'pshop_menu_select';
-    var selection = get_menu_option(input, 'pshop_main_menu');
+    var selection = get_menu_option(input, menuTable);
 
     // if menu selection is null/undefined, print error message and request new selection
     if(selection === null || selection === undefined){
@@ -153,7 +179,7 @@ addInputHandler('get_new_code', function(input){
         }
     }
     else{
-        var menu = populate_menu('pshop_main_menu', lang);
+        var menu = populate_menu(menuTable, lang);
         state.vars.current_menu_str = menu;
         sayText(menu);
         promptDigits('pshop_menu_select', { 'submitOnHash' : false,
@@ -164,7 +190,7 @@ addInputHandler('get_new_code', function(input){
 
 // input handler for back to main; returns user to the main menu
 addInputHandler('back_to_main', function(input){
-    var menu = populate_menu('pshop_main_menu', lang);
+    var menu = populate_menu(menuTable, lang);
     state.vars.current_menu_str = menu;
     sayText(menu);
     promptDigits('pshop_menu_select', { 'submitOnHash' : false,
@@ -177,7 +203,7 @@ addInputHandler('serial_no_reg', function(input){
     // if user wants to register, run serial # registration check and display corresponding messages/options 
     input = String(input.replace(/\D/g,''));
     if(input === '99'){
-        var menu = populate_menu('pshop_main_menu', lang);
+        var menu = populate_menu(menuTable, lang);
         state.vars.current_menu_str = menu;
         sayText(menu);
         promptDigits('pshop_menu_select', { 'submitOnHash' : false,

--- a/rw-legacy/pshops.js
+++ b/rw-legacy/pshops.js
@@ -26,6 +26,10 @@ else{
     service.vars.serial_number_table = 'dev_SeriaNumberTable';
     service.vars.pShop_main_menu = 'dev_pshop_main_menu';
 }
+
+service.vars.server_name = project.vars[env+'_server_name'];
+service.vars.roster_api_key = project.vars[env+'_roster_api_key'];
+
  
 // load in necessary functions
 var msgs = require('./lib/msg-retrieve'); // global message handler
@@ -36,6 +40,7 @@ var check_account_no = require('./lib/psh-check-account');
 var registration_check = require('./lib/psh-reg-check');
 var renew_code = require('./lib/psh-renew-code');
 var serial_no_check = require('./lib/psh-serial-verify');
+var slack = require('../slack-logger/index');
 
 // set various constants
 var settings_table = project.getOrCreateDataTable('ussd_settings');
@@ -80,7 +85,8 @@ addInputHandler('account_number_splash', function(accnum){
         // if error occurs, print client error message, log error, and alert the admin
         sayText(msgs('client_alert'));
         console.log(error);
-        admin_alert('Error on USSD test integration : '+ error + '\nAccount number: ' + accnum, "ERROR, ERROR, ERROR")
+        slack.log('Error on USSD test integration' +error + '\n Account number:' + accnum, "Error, ERROR, ERROR" )
+        //admin_alert('Error on USSD test integration : '+ error + '\nAccount number: ' + accnum, "ERROR, ERROR, ERROR")
         stopRules();
     }
 });


### PR DESCRIPTION
Ser 34: Update PShops PAYG code retrieval to include product type (Biolite vs Sun King)
Ser 26: update PShops to support new vendor
When a new user registers, the product type should be saved as biolite in the serial number table and we look for a biolite serial number in the activation tables and provide it to them. Account number to test:
o	To register an account number that did not unlock use 22263030, serial number: 1833482


When a user wants to retrieve an activation code, we check if the product type is biolite, then retrieve the code depending on the product type in the serial number table.
o	Check newly registered user(biolite)-first register them in the step above: 22263030 serial number: 1833482
o	Existing user checking (non-biotite): 22262946 serialnber : 4254686
o	The existing user that unlocked use:19759654(not biolite)
o	Biolite user that unlocked: 22262951
