### PR TITLE
Update the "total" field on the receipts so that it's rounded to the nearest zero

### DIFF
--- a/duka-receipts/dukaReceipts.js
+++ b/duka-receipts/dukaReceipts.js
@@ -20,9 +20,10 @@
     });
 
     var total_cost = response.amount || totalCost;
+    var rounded_total_cost =  Math.round(total_cost).toFixed(2);
     
     var vatCost = total_cost - productCost;
-    var SMStext = 'Thank you for shopping at the OAF Duka! Date: ' + response.date + ' Invoice nro: ' + response.receipt + ' Product cost: KES ' + productCost + ' VAT: KES ' + vatCost.toFixed(2) + ' Total: KES ' + totalCost;
+    var SMStext = 'Thank you for shopping at the OAF Duka! Date: ' + response.date + ' Invoice nro: ' + response.receipt + ' Product cost: KES ' + productCost + ' VAT: KES ' + vatCost.toFixed(2) + ' Total: KES ' + rounded_total_cost;
     var RouteIDPush = project.vars.route_push;
     var Label = project.getOrCreateLabel('Duka Receipt');
     console.log('sent message' + SMStext);

--- a/duka-receipts/dukaReceipts.test.js
+++ b/duka-receipts/dukaReceipts.test.js
@@ -40,7 +40,7 @@ describe('Mobile Money receipts', () => {
     it('should send an updated receips message', () => {
         jest.spyOn(project, 'getOrCreateLabel').mockReturnValue({id: 1});
         require('./dukaReceipts');
-        expect(project.sendMessage).toHaveBeenCalledWith({'content': 'Thank you for shopping at the OAF Duka! Date: 2020-07-26 Invoice nro: 54003657 Product cost: KES 538.61 VAT: KES 61.39 Total: KES 600.01',
+        expect(project.sendMessage).toHaveBeenCalledWith({'content': 'Thank you for shopping at the OAF Duka! Date: 2020-07-26 Invoice nro: 54003657 Product cost: KES 538.61 VAT: KES 61.39 Total: KES 600.00',
             'label_ids': [1], 
             'route_id': 'ts7ajag2saGA82ya8',
             'to_number': '0750475911'});


### PR DESCRIPTION
The stakeholder would like for the "total" field on duka receipts to be rounded to the nearest zero, as that will make it match our POS system. Please find an example below:

... other part of the message ....
**Total: Ksh.1150.00** (this is rounded from **1150.16**)