### PR TITLE
fixing assinging a non stringified objects to the state variable

### DIFF
--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -1040,7 +1040,7 @@ var MainMenuText = function(client){
         state.vars.multiple_input_menus = 1;
         state.vars.input_menu_length = Object.keys(menu).length; //this will be 1 greater than max possible loc
         sayText(menu[state.vars.input_menu_loc]);
-        state.vars.main_menu = menu;
+        state.vars.main_menu = menu[state.vars.input_menu_loc];
         state.vars.input_menu = JSON.stringify(menu);
     }
 
@@ -1057,7 +1057,7 @@ var NonClientMenuText = function (){
     else if (typeof (menu) == 'object') {
         state.vars.input_menu_loc = 0; //watch for off by 1 errors - consider moving this to start at 1
         state.vars.multiple_input_menus = 1;
-        state.vars.main_menu = menu;
+        state.vars.main_menu = menu[state.vars.input_menu_loc];
         state.vars.input_menu_length = Object.keys(menu).length; //this will be 1 greater than max possible loc
         sayText(menu[state.vars.input_menu_loc]);
         state.vars.input_menu = JSON.stringify(menu);
@@ -1678,7 +1678,7 @@ addInputHandler('SplashMenu', function(SplashMenu) {
             client = RosterClientGet(ClientAccNum);
             //console.log('Client JSON******************************'+JSON.stringify(client)+'******************');
             state.vars.client_json = JSON.stringify(client);
-            // check for goroup leader
+            // check for group leader
             var isGroupLeader = checkGroupLeader(client.DistrictId, client.ClientId);
             state.vars.isGroupLeader = isGroupLeader;
             state.vars.client = JSON.stringify(TrimClientJSON(client));


### PR DESCRIPTION
at some moments, when the menu gets to more than one page, it became an **object** instead of a **string**. This fix makes sure that right menu (string) is assigned to the state variable.

This is in response to ticket SER-168. users were not able to access the group summary option on the menu, but it turns out the issue is that the accounts used were not group leaders in the current season.