### PR TITLE
SER-150 restructured the all candidate extension table

### DIFF
--- a/tester-pack/confirmation/inputHandlers/receptionHandler.js
+++ b/tester-pack/confirmation/inputHandlers/receptionHandler.js
@@ -6,21 +6,43 @@ module.exports = function receptionHandler(input) {
     var getMessage = translator(translations, lang);
     var farmer = JSON.parse(state.vars.selected_farmer);
     var farmers_table = project.initDataTableById(service.vars.ExtensionFarmers);
+    var all_farmers_table = project.initDataTableById(service.vars.extensionTableId);
     var farmer_row = farmers_table.queryRows({
         vars: {'national_id': farmer.national_id}
     });
-    var nextedRow;
+    var farmer_row_in_all_farmers_table = all_farmers_table.queryRows({
+        vars: {'national_id': farmer.national_id}
+    });
+    var nextedRow,allFarmersTablerow;
     if(input == 1) {
-        while(farmer_row.hasNext()) {
+        if(farmer_row.hasNext()) {
             nextedRow = farmer_row.next();
             nextedRow.vars.received_tester_pack = true;
             nextedRow.save();
         }
+        if(farmer_row_in_all_farmers_table.hasNext()) {
+            allFarmersTablerow = farmer_row_in_all_farmers_table.next();
+            allFarmersTablerow.vars.client_received_tester_pack = 'yes';
+            if(allFarmersTablerow.vars.time_created_confirmation == null || allFarmersTablerow.vars.time_created_confirmation == undefined){
+                allFarmersTablerow.vars.time_created_confirmation = new Date().toString();
+            }
+            allFarmersTablerow.vars.last_updated_confirmation = new Date().toString();
+            allFarmersTablerow.save();
+        }
     } else if(input == 2) {
-        while(farmer_row.hasNext()) {
+        if(farmer_row.hasNext()) {
             nextedRow = farmer_row.next();
             nextedRow.vars.received_tester_pack = false;
             nextedRow.save();
+        }
+        if(farmer_row_in_all_farmers_table.hasNext()) {
+            allFarmersTablerow = farmer_row_in_all_farmers_table.next();
+            allFarmersTablerow.vars.client_received_tester_pack = 'no';
+            if(allFarmersTablerow.vars.time_created_confirmation == null || allFarmersTablerow.vars.time_created_confirmation == undefined ){
+                allFarmersTablerow.vars.time_created_confirmation = new Date().toString();
+            }
+            allFarmersTablerow.vars.last_updated_confirmation = new Date().toString();
+            allFarmersTablerow.save();
         }
     } else {
         sayText(getMessage('invalid_input', {'$Menu': getMessage('confirm_reception', {}, lang)}, lang));

--- a/tester-pack/confirmation/inputHandlers/receptionHandler.test.js
+++ b/tester-pack/confirmation/inputHandlers/receptionHandler.test.js
@@ -2,7 +2,8 @@
 var receptionHandler = require('./receptionHandler');
 
 
-
+var mockedTable = { queryRows: jest.fn()};
+var mockedRow = {save: jest.fn(),hasNext: jest.fn(), next: jest.fn(),vars: {'client_received_tester_pack': null,'received_tester_pack': null,'time_created_confirmation': null}}; 
 describe('reception Handler', () => {
     beforeAll(() => {
         global.state = { vars: {lang: 'en'} };
@@ -15,15 +16,13 @@ describe('reception Handler', () => {
 
     const table_cursor = {
         currentIndex: -1,
-        results: [{vars: {received_tester_pack: undefined}, save: mockFunction}],
+        results: [{vars: {received_tester_pack: undefined, time_created_confirmation: null}, save: mockFunction}],
         hasNext: () => table_cursor.results[table_cursor.currentIndex + 1] && true,
         next: () => { 
             table_cursor.currentIndex += 1;
             return table_cursor.results[table_cursor.currentIndex];
         }
     };
-
-
     it('should change the value to true upon selection of 1', () => {
         const table = {queryRows: () => table_cursor};
         project.initDataTableById = () => table;
@@ -52,5 +51,42 @@ describe('reception Handler', () => {
             maxDigits: 2,
             submitOnHash: false
         });
+    });
+    it('should change the value of client_received_tester_pack to yes if the user chooses 2', () => {
+    
+        project.initDataTableById = jest.fn().mockReturnValue(mockedTable);
+        mockedRow.next.mockReturnValue(mockedRow);
+        mockedTable.queryRows.mockReturnValue(mockedRow);
+        mockedRow.hasNext.mockReturnValue(true);
+        project.initDataTableById = jest.fn().mockReturnValue(mockedTable);
+        receptionHandler(2);
+        expect(mockedRow.save).toHaveBeenCalledTimes(2);
+        expect(mockedRow.vars.client_received_tester_pack).toEqual('no');
+    });
+    it('should change the value of client_received_tester_pack to yes if the client chooses 1', () => {
+        receptionHandler(1);
+        expect(mockedRow.save).toHaveBeenCalledTimes(2);
+        expect(mockedRow.vars.client_received_tester_pack).toEqual('yes');
+        expect(mockedRow.vars.time_created_confirmation).toEqual(new Date().toString());
+    });
+    it('should change the time created for confirmation and last updated to now if the client chooses 1 and it\'s the first time', () => {
+        receptionHandler(1);
+        expect(mockedRow.vars.time_created_confirmation).toEqual(new Date().toString());
+        expect(mockedRow.vars.last_updated_confirmation).toEqual(new Date().toString());
+    });
+    it('should change set the time created for confirmation and last updated to now if the client chooses 2 and it\'s the first time', () => {
+        receptionHandler(2);
+        expect(mockedRow.vars.time_created_confirmation).toEqual(new Date().toString());
+        expect(mockedRow.vars.last_updated_confirmation).toEqual(new Date().toString());
+    });
+    it('should change the time updated for confirmation to now if the client chooses 1 and it\'s not the first time', () => {
+        mockedRow.vars.time_created_confirmation = new Date().toString();
+        receptionHandler(1);
+        expect(mockedRow.vars.last_updated_confirmation).toEqual(new Date().toString());
+    });
+    it('should change the time updated for confirmation to now if the client chooses 2 and it\'s not the first time', () => {
+        mockedRow.vars.time_created_confirmation = new Date().toString();
+        receptionHandler(2);
+        expect(mockedRow.vars.last_updated_confirmation).toEqual(new Date().toString());
     });
 });

--- a/tester-pack/confirmation/inputHandlers/receptionHandler.test.js
+++ b/tester-pack/confirmation/inputHandlers/receptionHandler.test.js
@@ -52,7 +52,7 @@ describe('reception Handler', () => {
             submitOnHash: false
         });
     });
-    it('should change the value of client_received_tester_pack to yes if the user chooses 2', () => {
+    it('should change the value of client_received_tester_pack to no if the user chooses 2', () => {
     
         project.initDataTableById = jest.fn().mockReturnValue(mockedTable);
         mockedRow.next.mockReturnValue(mockedRow);
@@ -87,6 +87,19 @@ describe('reception Handler', () => {
     it('should change the time updated for confirmation to now if the client chooses 2 and it\'s not the first time', () => {
         mockedRow.vars.time_created_confirmation = new Date().toString();
         receptionHandler(2);
+        expect(mockedRow.vars.last_updated_confirmation).toEqual(new Date().toString());
+    });
+    
+    it('should change the time created and last updated for confirmation to now if the client chooses 2 and it\'s not the first time(undefined)', () => {
+        mockedRow.vars.time_created_confirmation = undefined;
+        receptionHandler(2);
+        expect(mockedRow.vars.time_created_confirmation).toEqual(new Date().toString());
+        expect(mockedRow.vars.last_updated_confirmation).toEqual(new Date().toString());
+    });
+    it('should change the time created and last updated for confirmation to now if the client chooses 2 and it\'s not the first time(undefined)', () => {
+        mockedRow.vars.time_created_confirmation = undefined;
+        receptionHandler(1);
+        expect(mockedRow.vars.time_created_confirmation).toEqual(new Date().toString());
         expect(mockedRow.vars.last_updated_confirmation).toEqual(new Date().toString());
     });
 });


### PR DESCRIPTION
updated the 'Extension Farmers All candidate' to stored these columns in addition: First Name, Last Name, Gender, National Id, Phone Number. Registration Status, Received Tester Pack, Sector, cell, Village, Village ID, Time Created | Last Updated(registration and confirmation)

testing link: https://telerivet.com/p/4bee87c0/service/SV80c59c2e64f4fe9d/edit

registration steps:
- select option 3 on the main menu
- select option 1 on the second menu
- for village Id you can use: 53040303
- any name(first name and last name)
- any valid phone number(eg:0786182098)
- any valid national Id (eg:1199780043907055)
- answer all question yes, except the second one to no(for a valid request) **for an invalid answer any question no except qn2**

The above columns should be saved

-confirmation steps:
- select option 3 from the main menu
- select option 2 on the second menu
- enter the village ID: 53040303(if used in the above step)
- select the created user from above
- enter the last 4 digits national Id(77055)
- answer yes/no 

It should update the above table



 