### PR TITLE
Bg fix tester pack

### DIFF
--- a/tester-pack/confirmation/inputHandlers/villageHandler.js
+++ b/tester-pack/confirmation/inputHandlers/villageHandler.js
@@ -16,6 +16,13 @@ module.exports = function villageHandler(input) {
         var farmers_table = project.initDataTableById(service.vars.ExtensionFarmers);
         var farmers_cursor = farmers_table.queryRows({vars: {'village_id': village.village_id}});
         var index = 0;
+        if(!farmers_cursor.hasNext()) {
+            // if no farmer has registered in the given village
+            console.log(JSON.stringify(village));
+            sayText(getMessage('no_farmers_found', {'$village_name': village.village_name}, lang));
+            stopRules();
+            return;
+        }
         while(farmers_cursor.hasNext()) {
             var row = farmers_cursor.next();
             var nid = row.vars.national_id;

--- a/tester-pack/confirmation/inputHandlers/villageHandler.js
+++ b/tester-pack/confirmation/inputHandlers/villageHandler.js
@@ -18,7 +18,6 @@ module.exports = function villageHandler(input) {
         var index = 0;
         if(!farmers_cursor.hasNext()) {
             // if no farmer has registered in the given village
-            console.log(JSON.stringify(village));
             sayText(getMessage('no_farmers_found', {'$village_name': village.village_name}, lang));
             stopRules();
             return;

--- a/tester-pack/confirmation/inputHandlers/villageHandler.test.js
+++ b/tester-pack/confirmation/inputHandlers/villageHandler.test.js
@@ -23,7 +23,7 @@ describe('Village handler', () => {
     };
 
     it('should promt the user to select a farmer once the input matches an existinf village', () => {
-        state.vars.villages = JSON.stringify({'1': {village: 'Mpazi', villageid: 1}, '2': {village: 'Tetero', villageid: 2}, '3': {village: 'Kinyambo', villageid: 3}});
+        state.vars.villages = JSON.stringify({'1': {village: 'Mpazi', village_id: 1}, '2': {village: 'Tetero', village_id: 2}, '3': {village: 'Kinyambo', village_id: 3}});
         state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n* Komeza', '2': '3) Kinyambo'});
         const table = {queryRows: () => table_cursor};
         project.initDataTableById = () => table;
@@ -31,7 +31,7 @@ describe('Village handler', () => {
         expect(state.vars.farmers).toEqual('{"1":{"national_id":"13753675","first_name":"Mosh","last_name":"Hamedani","row_id":1},"2":{"national_id":"11437284",' + 
         '"first_name":"Brad","last_name":"Traversy","row_id":2},"3":{"national_id":"11433948","first_name":"Fun","last_name":"Function","row_id":3}}');
         
-        expect(state.vars.villages).toEqual('{"1":{"village":"Mpazi","villageid":1},"2":{"village":"Tetero","villageid":2},"3":{"village":"Kinyambo","villageid":3}}');
+        expect(state.vars.villages).toEqual('{"1":{"village":"Mpazi","village_id":1},"2":{"village":"Tetero","village_id":2},"3":{"village":"Kinyambo","village_id":3}}');
         expect(state.vars.current_farmers_screen).toEqual(1);
         expect(sayText).toHaveBeenCalledWith('Press the number corresponding to farmer who is receiving the tester pack\n' +
         '1) Mosh Hamedani\n' +
@@ -39,8 +39,21 @@ describe('Village handler', () => {
         '3) Fun Function\n');
         expect(promptDigits).toHaveBeenCalledWith('select_farmer', {'maxDigits': 2, 'submitOnHash': false, 'timeout': 5});
     });
+
+    it('should tell the user if there are no registered farmers in the selected village', () => {
+        state.vars.villages = JSON.stringify({'1': {village_name: 'Mpazi', village_id: 1}, '2': {village_name: 'Tetero', village_id: 2}, '3': {village_name: 'Kinyambo', village_id: 3}});
+        state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n* Komeza', '2': '3) Kinyambo'});
+        table_cursor.results = [];
+        const table = {queryRows: () => table_cursor};
+        project.initDataTableById = () => table;
+        villageHandler(1);
+        expect(sayText).toHaveBeenCalledWith('No registered farmers in Mpazi village');
+        expect(stopRules).toHaveBeenCalled();
+        expect(promptDigits).not.toHaveBeenCalled();
+    });
+
     it('should display a next page when a user inputs *', () => {
-        state.vars.villages = JSON.stringify({'1': {village: 'Mpazi', villageid: 1}, '2': {village: 'Tetero', villageid: 2}, '3': {village: 'Kinyambo', villageid: 3}});
+        state.vars.villages = JSON.stringify({'1': {village: 'Mpazi', village_id: 1}, '2': {village: 'Tetero', village_id: 2}, '3': {village: 'Kinyambo', village_id: 3}});
         state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n* Komeza', '2': '3) Kinyambo'});
         state.vars.current_villages_screen = 1;
         project.initDataTableById = jest.fn();
@@ -51,7 +64,7 @@ describe('Village handler', () => {
     });
 
     it('should display a next page when a user inputs *', () => {
-        state.vars.villages = JSON.stringify({'1': {village: 'Mpazi', villageid: 1}, '2': {village: 'Tetero', villageid: 2}, '3': {village: 'Kinyambo', villageid: 3}});
+        state.vars.villages = JSON.stringify({'1': {village: 'Mpazi', village_id: 1}, '2': {village: 'Tetero', village_id: 2}, '3': {village: 'Kinyambo', village_id: 3}});
         state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n* Komeza', '2': '3) Kinyambo'});
         state.vars.current_villages_screen = 2;
         project.initDataTableById = jest.fn();

--- a/tester-pack/confirmation/translations/index.js
+++ b/tester-pack/confirmation/translations/index.js
@@ -13,7 +13,7 @@ var translations = {
     },
     'provinces': {
         'en': '1) EASTERN ZONE\n2) KIGALI CITY\n3) SOUTHERN ZONE\n4) WESTERN ZONE\n5) NORTHERN ZONE',
-        'ki': '1) EASTERN ZONE\n2) KIGALI CITY\n3) SOUTHERN ZONE\n4) WESTERN ZONE\n5) NORTHERN ZONE'
+        'ki': '1) IBURASIRAZUBA\n2) UMUGI WA KIGALI\n3) AMAJYEPFO\n4) IBURENGERAZUBA\n5) AMAJYARUGURU'
     },
     'locations': {
         'en': '$label) $location\n',
@@ -42,6 +42,10 @@ var translations = {
     'village_title': {
         'en': 'Village\n',
         'ki': 'Umudugudu\n'
+    },
+    'no_farmers_found': {
+        'en': 'No registered farmers in $village_name village',
+        'ki': 'Nta bahinzi bariyandikisha m\'umudugudu wa $village_name'
     },
     'farmers_title': {
         'en': 'Press the number corresponding to farmer who is receiving the tester pack\n',


### PR DESCRIPTION
### SER-194 Adding the provinces kinyarwanda translations
https://telerivet.com/p/4bee87c0/service/SVa2e7a19f20dc2bc8/edit
 **demonstration**
- dial the short code
- choose tester pack (3)
- choose confirmation (2)
there will be a list of provinces in Kinyarwanda instead of the previous behaviors where provinces were in english

_________________________________________________________________

### SER-193 Adding the notice once no farmers are found in the selected village
https://telerivet.com/p/4bee87c0/service/SVa2e7a19f20dc2bc8/edit
this usually given **undefined** but it is now notifying the user that the selected village has no farmer
**demonstration**
- dial the short code
- choose tester pack (3)
- choose confirmation (2)
- choose any district other than KIgali since only one sector in Kigali has test data.
- continue choosing on options give. at the end, after choosing a village, you should receive a notice that the selected village has no registered farmers
