### PR TITLE
(hotfix) fixing the solar payg code retrieval

### DIFF
--- a/rw-legacy/core.js
+++ b/rw-legacy/core.js
@@ -220,34 +220,22 @@ addInputHandler('cor_menu_select', function (input) {
     }
     else if (selection === 'cor_get_payg') {
         var payg_retrieve = require('./lib/cor-payg-retrieve');
-        var payg_balance = require('./lib/cor-payg-balance');
-        console.log("PAYG balance is " + payg_balance(JSON.parse(state.vars.client_json)));
-
-        // only run code if client has paid enough; otherwise tell them they haven't paid enough for a new code
-        if (payg_balance(JSON.parse(state.vars.client_json))) {
             // if account matches a serial number, give the client the corresponding PAYG code
-            if (payg_retrieve(state.vars.account_number)) {
-                sayText(msgs('cor_payg_true', { '$PAYG': state.vars.payg_code }, lang));
-                promptDigits('cor_continue', { 'submitOnHash': false, 'maxDigits': max_digits_for_input, 'timeout': timeout_length });
-                return null;
-            }
-            // else prompt the client to enter their product's serial number
-            else if (state.vars.acc_empty) {
-                sayText(msgs('cor_payg_false', {}, lang));
-                promptDigits('cor_payg_reg', { 'submitOnHash': false, 'maxDigits': max_digits_for_account_number, 'timeout': timeout_length });
-                return null;
-            }
-            // print an error message if an error occurs
-            else {
-                sayText(msgs('cor_payg_duplicate', {}, lang));
-                promptDigits('cor_payg_reg', { 'submitOnHash': false, 'maxDigits': max_digits_for_account_number, 'timeout': timeout_length });
-                return null;
-            }
-        }
-        // if client doesn't have sufficient balance, tell them they haven't paid enough for a new code
-        else {
-            sayText(msgs('cor_payg_insufficient', {}, lang));
+        if (payg_retrieve(state.vars.account_number)) {
+            sayText(msgs('cor_payg_true', { '$PAYG': state.vars.payg_code }, lang));
             promptDigits('cor_continue', { 'submitOnHash': false, 'maxDigits': max_digits_for_input, 'timeout': timeout_length });
+            return null;
+        }
+        // else prompt the client to enter their product's serial number
+        else if (state.vars.acc_empty) {
+            sayText(msgs('cor_payg_false', {}, lang));
+            promptDigits('cor_payg_reg', { 'submitOnHash': false, 'maxDigits': max_digits_for_account_number, 'timeout': timeout_length });
+            return null;
+        }
+        // print an error message if an error occurs
+        else {
+            sayText(msgs('cor_payg_duplicate', {}, lang));
+            promptDigits('cor_payg_reg', { 'submitOnHash': false, 'maxDigits': max_digits_for_account_number, 'timeout': timeout_length });
             return null;
         }
     }


### PR DESCRIPTION
- recently, users could only retrieve solar payg code if and only if they have met the payment threshold
- currently, users can retrieve the solar payg code regardless of their balance
[Finishes #SER-197]

Test from 
Account number: 18659550

**old implementation**
https://telerivet.com/p/8799a79f/service/SV0f1e9ba5632d5274/edit
this should not give the payg code since the account 18659550 has not paid to the threshold payment. instead it should give a message about user being unable to retrieve the paygcode.

**new implementation**
https://telerivet.com/p/8799a79f/service/SV215b0cbe269df25d/edit
since the condition has been eliminated, you can now get the paygcode for this user.