### PR TITLE
Ser 182 prevent new client from being enrolled multiple times

### DIFF
--- a/client-enrollment/clientEnrollment.js
+++ b/client-enrollment/clientEnrollment.js
@@ -12,48 +12,58 @@ module.exports = {
         state.vars.enr_lang = lang;
         notifyELK();
         var translate =  createTranslator(translations,state.vars.enr_lang);
-        var client_auth = roster.authClient(state.vars.account, country);
-        if(client_auth){
-            var client = roster.getClient(state.vars.account, state.vars.country);
-        }
-        if(client){
-            var remainingLoan = 0;
-            if(client.BalanceHistory.length > 0){
-                client.latestBalanceHistory = client.BalanceHistory[0];
-                remainingLoan = client.latestBalanceHistory.TotalCredit - client.latestBalanceHistory.TotalRepayment_IncludingOverpayments;
-            }
-            console.log('remaining loan:'+ remainingLoan);
-            if(remainingLoan > 0 ){
-                sayText(translate('loan_payment_not_satisfied',{'$amount': remainingLoan },state.vars.enr_lang));
-            }
-            else{
-                var foInfo = getFOInfo(client.DistrictId,client.SiteId,state.vars.enr_lang);
-                var message;
-                if(foInfo == null || (foInfo.phoneNumber == null || foInfo.phoneNumber == undefined)){
-                    message = translate('registration_message_no_phone',{},state.vars.enr_lang );
-                }else{
-                    message = translate('registration_message' , {'$phone': foInfo.phoneNumber}, state.vars.enr_lang);
-                }
-                sayText(message);
-                project.sendMessage({
-                    content: message, 
-                    to_number: contact.phone_number
-                });
-                var table = project.initDataTableById(service.vars.lr_2021_client_table_id);
-                var row = table.createRow({
-                    'contact_id': contact.id,
-                    'from_number': contact.from_number,
-                    'vars': {
-                        'account_number': client.AccountNumber,
-                        'national_id': client.NationalId,
-                        'new_client': '0'
-                    }
-                });
-                row.save();
-            }
+        var clientTable = project.initDataTableById(service.vars.lr_2021_client_table_id);
+        var duplicateRows = clientTable.queryRows({'vars': {'account_number': account}});
+        if(duplicateRows.hasNext()){
+            var duplicateRow = duplicateRows.next();
+            global.sayText(translate('duplicate_national_id',{'$AccountNumber': duplicateRow.vars.account_number},state.vars.reg_lang)); 
         }
         else{
-            sayText(translate('account_not_found',{},state.vars.enr_lang));
+            var client_auth = roster.authClient(state.vars.account, country);
+            if(client_auth){
+                var client = roster.getClient(state.vars.account, state.vars.country);
+            }
+            if(client){
+
+                var remainingLoan = 0;
+                if(client.BalanceHistory.length > 0){
+                    client.latestBalanceHistory = client.BalanceHistory[0];
+                    remainingLoan = client.latestBalanceHistory.TotalCredit - client.latestBalanceHistory.TotalRepayment_IncludingOverpayments;
+                }
+                console.log('remaining loan:'+ remainingLoan);
+
+                if(remainingLoan > 0 ){
+                    sayText(translate('loan_payment_not_satisfied',{'$amount': remainingLoan },state.vars.enr_lang));
+                }
+                else{
+                    var foInfo = getFOInfo(client.DistrictId,client.SiteId,state.vars.enr_lang);
+                    var message;
+                    if(foInfo == null || (foInfo.phoneNumber == null || foInfo.phoneNumber == undefined)){
+                        message = translate('registration_message_no_phone',{},state.vars.enr_lang );
+                    }else{
+                        message = translate('registration_message' , {'$phone': foInfo.phoneNumber}, state.vars.enr_lang);
+                    }
+                    sayText(message);
+                    project.sendMessage({
+                        content: message, 
+                        to_number: contact.phone_number
+                    });
+                    var table = project.initDataTableById(service.vars.lr_2021_client_table_id);
+                    var row = table.createRow({
+                        'contact_id': contact.id,
+                        'from_number': contact.from_number,
+                        'vars': {
+                            'account_number': client.AccountNumber,
+                            'national_id': client.NationalId,
+                            'new_client': '0'
+                        }
+                    });
+                    row.save();
+                }
+            }
+            else{
+                sayText(translate('account_not_found',{},state.vars.enr_lang));
+            }
         }
     }
 

--- a/client-enrollment/test.js
+++ b/client-enrollment/test.js
@@ -10,16 +10,19 @@ const account = 123456789;
 const country = 'KE';
 const enr_lang = 'en-ke';
 const foPhone = '0786182098';
-var mockTable = { createRow: jest.fn()};
-var mockRow = {save: jest.fn()};
+var mockTable = { createRow: jest.fn(), queryRows: jest.fn()};
+var mockRow = {save: jest.fn(),next: jest.fn(), hasNext: jest.fn(),vars: {'account_number': account}};
 describe('clientRegistration', () => {
     beforeAll(()=>{
         roster.getClient = jest.fn();
         roster.authClient = jest.fn();
         project.sendMessage = jest.fn();
-        project.initDataTableById = jest.fn();
         mockTable.createRow.mockReturnValue(mockRow);
-        project.initDataTableById.mockReturnValue(mockTable);
+        project.initDataTableById = jest.fn().mockReturnValue(mockTable);
+        mockTable.queryRows.mockReturnValue(mockRow);
+        mockRow.hasNext.mockReturnValue(false);
+        mockRow.next.mockReturnValue(mockRow);
+
     });
     beforeEach(()=>{
         roster.authClient = jest.fn().mockImplementationOnce(() => {
@@ -140,6 +143,12 @@ describe('clientRegistration', () => {
             expect(sayText).toHaveBeenCalledWith(`Thank you for expressing your interest to enrol for 2021. Please pay KSHs ${loanAmount} `+
             'to finish your loan then try again!');
             expect(sayText).toHaveBeenCalledTimes(1);
+        });
+        it('should display a message with an account number if a duplicate account number is found in the tables', () => {
+            mockRow.hasNext.mockReturnValue(true);
+            clientEnrollment.start(account, country,enr_lang);
+            expect(sayText).toHaveBeenCalledWith(`You have already enrolled this season and your account number is ${account}`+
+            '. Reach out to your FO to help you add inputs to your order.');
         });
         
     });

--- a/client-enrollment/translations.js
+++ b/client-enrollment/translations.js
@@ -15,6 +15,10 @@ module.exports = {
     'loan_payment_not_satisfied': {
         'en-ke': 'Thank you for expressing your interest to enrol for 2021. Please pay KSHs $amount to finish your loan then try again!',
         'sw': 'Asante kwa kuonesha nia ya kujiandikisha mwaka wa 2021. Tafadhali lipa shilingi $amount umalize mkopo wako, kisha ujaribu tena!'
+    },
+    'duplicate_national_id': {
+        'en-ke': 'You have already enrolled this season and your account number is $AccountNumber. Reach out to your FO to help you add inputs to your order.',
+        'sw': 'Tayari umesajiliwa mwaka huu na akauti namba yako ni $AccountNumber Tembelea mwalimu wako ili akusaidie kuongeza bidhaa unazotaka!'
     }
 
 };

--- a/client-registration/clientRegistration.js
+++ b/client-registration/clientRegistration.js
@@ -15,9 +15,17 @@ module.exports = {
     registerHandlers: function (){
         
         function onNationalIdValidated(nationalId){
-            state.vars.nationalId = nationalId;
-            global.sayText(translate('confirm_national_id',{'$nationalId': nationalId},state.vars.reg_lang));
-            global.promptDigits(confirmNationalIdHandler.handlerName);
+            var table = project.initDataTableById(service.vars.lr_2021_client_table_id);
+            var rows = table.queryRows({'vars': {'national_id': nationalId}});
+            if(rows.hasNext()){
+                var row = rows.next();
+                global.sayText(translate('duplicate_national_id',{'$AccountNumber': row.vars.account_number},state.vars.reg_lang)); 
+            }
+            else{
+                state.vars.nationalId = nationalId;
+                global.sayText(translate('confirm_national_id',{'$nationalId': nationalId},state.vars.reg_lang));
+                global.promptDigits(confirmNationalIdHandler.handlerName);
+            }
         }
         function onNationalIdConfirmation(){
             global.sayText(translate('first_name_prompt',{},state.vars.reg_lang));

--- a/client-registration/national-id-handler/nationalIdHandler.js
+++ b/client-registration/national-id-handler/nationalIdHandler.js
@@ -2,6 +2,7 @@ var createTranslator = require('../../utils/translator/translator');
 var translations = require('../translations');
 var translate =  createTranslator(translations,  state.vars.reg_lang || 'en-ke');
 var notifyELK = require('../../notifications/elk-notification/elkNotification');
+
 var isNationalIdValid= function(nId){
     var idLength = nId.length;
     //Different country have different national Id digits length

--- a/client-registration/test.js
+++ b/client-registration/test.js
@@ -36,6 +36,10 @@ const reg_lang = 'en-ke';
 const nationalId = 12345678;
 const phone = '0786182099';
 var foPhone = '0786192039';
+
+var mockedTable = { queryRows: jest.fn()};
+var mockedRow = {hasNext: jest.fn(), next: jest.fn(),vars: {'national_id': nationalId,'account_number': account}};
+
 describe('clientRegistration', () => {
 
     it('should have a start function', () => {
@@ -86,13 +90,25 @@ describe('clientRegistration', () => {
             clientRegistration.registerHandlers();
             callback = nationalIdHandler.getHandler.mock.calls[0][0];                
         });
-        it('should tell the client to confirm the national Id they have entered', () => {
+        it('should display a message with an account number if a duplicate national id is found in the tables', () => {
+            project.initDataTableById = jest.fn().mockReturnValue(mockedTable);
+            mockedTable.queryRows.mockReturnValue(mockedRow);
+            mockedRow.hasNext.mockReturnValue(true);
+            mockedRow.next.mockReturnValue(mockedRow);
             callback(nationalId);
-            expect(sayText).toHaveBeenCalledWith(`You enter ${nationalId} ID`+
+            expect(sayText).toHaveBeenCalledWith(`You have already enrolled this season and your account number is ${account}`+
+            '. Reach out to your FO to help you add inputs to your order.');
+        });
+        it('should tell the client to confirm the national Id they have entered', () => {
+            mockedRow.hasNext.mockReturnValue(false);
+            var differentId = '12385679';
+            callback(differentId);
+            expect(sayText).toHaveBeenCalledWith(`You enter ${differentId} ID`+
             '. Enter 1 to confirm or 2 to try again');
         });
         it('should prompt for the client to confirm their national Id', () => {
-            callback();
+            var differentId = '12385679';
+            callback(differentId);
             expect(promptDigits).toHaveBeenCalledWith(confrmNationalIdHandler.handlerName);
         });
     });
@@ -248,6 +264,12 @@ describe('clientRegistration', () => {
                 to_number: state.vars.phoneNumber
             }));
         });
+        it('should send a message with no FO phone number to the new client phone number if the FO phone number is not available', () => {  
+            getFOInfo.mockImplementationOnce(() => {return {'firstName': 'sabin','lastName': 'sheja','phoneNumber': null};});
+            callback();
+            expect(sayText).toHaveBeenCalledWith(`Thank you for expressing your interest to enroll with OAF. Your Account Number is: ${client.AccountNumber}`+
+                '. Your FO will reach out to you to add inputs to your order.');
+        });
         
         it('should send a message with no FO phone number to the GL phone number if the FO contact is not available', () => {  
             getFOInfo.mockImplementationOnce(() => {return null;});
@@ -267,7 +289,7 @@ describe('clientRegistration', () => {
                 to_number: state.vars.phoneNumber
             }));
         });
-        it('should show a message with no FO phone number if the FO phone is not available', () => {  
+        it('should show a message with no FO phone number if the FO details is not available', () => {  
             getFOInfo.mockImplementationOnce(() => {return null;});
             callback();
             expect(sayText).toHaveBeenCalledWith(`Thank you for expressing your interest to enroll with OAF. Your Account Number is: ${client.AccountNumber}`+

--- a/client-registration/translations.js
+++ b/client-registration/translations.js
@@ -44,5 +44,9 @@ module.exports = {
     'reg_group_leader_question': {
         'en-ke': 'Does the farmer want to be a Group Leader of a new group?\n1) Yes\n2) No',
         'sw': 'Je mkulima huyu angetaka kuwa Kiongozi wa kikundi kipya?\n1) Ndio\n2) Hapana'
+    },
+    'duplicate_national_id': {
+        'en-ke': 'You have already enrolled this season and your account number is $AccountNumber. Reach out to your FO to help you add inputs to your order.',
+        'sw': 'Tayari umesajiliwa mwaka huu na akauti namba yako ni $AccountNumber Tembelea mwalimu wako ili akusaidie kuongeza bidhaa unazotaka!'
     }
 };


### PR DESCRIPTION
This PR was merged in develop but is needed on master as hotfix(SER-200)


SER-182-prevent-new-clients-from-being-enrolled-multiple-times:

-Added a check for national Id in the client's table when a user is registering and a check for a duplicate account number when a user is enrolling.

Testing link: https://telerivet.com/p/0c6396c9/service/SVb47209de1fdd2cf0/edit

Steps:

Enter an account number: 24450523
Select 3 on the next menu (enroll)
enter an account number: 26931220 ** It should prevent you from registering and display a message **
for registration:

Enter an account number: 24450523
select 3 for enrollment
enter zero for new client registration
enter a used national Id 98765432 ** It should prevent you from registering and display a message with your account number **