### PR TITLE
edited the registration main menu, kenya registration table columns r…

### DIFF
--- a/client-registration/clientRegistration.js
+++ b/client-registration/clientRegistration.js
@@ -72,17 +72,17 @@ module.exports = {
                 var table = project.initDataTableById(service.vars.lr_2021_client_table_id);
                 var row = table.createRow({
                     'contact_id': contact.id,
-                    'from_number': contact.from_number,
                     vars: {
                         'account_number': clientData.AccountNumber,
                         'national_id': clientData.NationalId,
-                        'phone_number': clientJSON.phoneNumber,
+                        'client_phone_number': clientJSON.phoneNumber,
                         'first_name': clientData.FirstName,
                         'last_name': clientData.LastName,
                         'district': clientData.DistrictId,
                         'site': clientData.SiteId,
                         'new_client': '1',
-                        'gl_interested': state.vars.groupLeader
+                        'gl_interested': state.vars.groupLeader,
+                        'gl_phone_number': contact.phone_number,
 
                     }
                 });

--- a/client-registration/clientRegistration.js
+++ b/client-registration/clientRegistration.js
@@ -55,38 +55,40 @@ module.exports = {
                 'phoneNumber': state.vars.phoneNumber
             };
             try {
-                var clientData = JSON.parse(rosterRegisterClient(clientJSON));
-                console.log('client Data ****************' + clientData.AccountNumber);
-                var getFOInfo = require('../Roster-endpoints/Fo-info/getFoInfo');
-                var foInfo = getFOInfo(clientData.DistrictId,clientData.SiteId,state.vars.reg_lang);
-                var message;
-                if((foInfo == null) || (foInfo.phoneNumber == null || foInfo.phoneNumber == undefined)){
-                    message = translate('reg_complete_message_no_phone' , {'$ACCOUNT_NUMBER': clientData.AccountNumber}, state.vars.reg_lang);
-                }
-                else{
-                    message = translate('reg_complete_message' , {'$ACCOUNT_NUMBER': clientData.AccountNumber,'$FOphone': foInfo.phoneNumber}, state.vars.reg_lang);
-                }
-                sayText(message);
-                project.sendMessage({content: message, to_number: contact.phone_number});
-                project.sendMessage({content: message, to_number: clientJSON.phoneNumber});
-                var table = project.initDataTableById(service.vars.lr_2021_client_table_id);
-                var row = table.createRow({
-                    'contact_id': contact.id,
-                    vars: {
-                        'account_number': clientData.AccountNumber,
-                        'national_id': clientData.NationalId,
-                        'client_phone_number': clientJSON.phoneNumber,
-                        'first_name': clientData.FirstName,
-                        'last_name': clientData.LastName,
-                        'district': clientData.DistrictId,
-                        'site': clientData.SiteId,
-                        'new_client': '1',
-                        'gl_interested': state.vars.groupLeader,
-                        'gl_phone_number': contact.phone_number,
-
+                var clientData = JSON.parse(rosterRegisterClient(clientJSON,state.vars.reg_lang));
+                if(clientData){
+                    console.log('client Data ****************' + clientData.AccountNumber);
+                    var getFOInfo = require('../Roster-endpoints/Fo-info/getFoInfo');
+                    var foInfo = getFOInfo(clientData.DistrictId,clientData.SiteId,state.vars.reg_lang);
+                    var message;
+                    if((foInfo == null) || (foInfo.phoneNumber == null || foInfo.phoneNumber == undefined)){
+                        message = translate('reg_complete_message_no_phone' , {'$ACCOUNT_NUMBER': clientData.AccountNumber}, state.vars.reg_lang);
                     }
-                });
-                row.save();
+                    else{
+                        message = translate('reg_complete_message' , {'$ACCOUNT_NUMBER': clientData.AccountNumber,'$FOphone': foInfo.phoneNumber}, state.vars.reg_lang);
+                    }
+                    sayText(message);
+                    project.sendMessage({content: message, to_number: contact.phone_number});
+                    project.sendMessage({content: message, to_number: clientJSON.phoneNumber});
+                    var table = project.initDataTableById(service.vars.lr_2021_client_table_id);
+                    var row = table.createRow({
+                        'contact_id': contact.id,
+                        vars: {
+                            'account_number': clientData.AccountNumber,
+                            'national_id': clientData.NationalId,
+                            'client_phone_number': clientJSON.phoneNumber,
+                            'first_name': clientData.FirstName,
+                            'last_name': clientData.LastName,
+                            'district': clientData.DistrictId,
+                            'site': clientData.SiteId,
+                            'new_client': '1',
+                            'gl_interested': state.vars.groupLeader,
+                            'gl_phone_number': contact.phone_number,
+
+                        }
+                    });
+                    row.save();
+                }
             }
             catch (e) {
                 console.log('error getting account number from roster' + e);

--- a/client-registration/test.js
+++ b/client-registration/test.js
@@ -189,6 +189,12 @@ describe('clientRegistration', () => {
             callback = groupLeaderQuestionHandler.getHandler.mock.calls[0][0];
             JSON.parse = jest.fn().mockImplementation(() => {return client ;});
         });
+        it('should not send message or save a row if the returned JSON from registering the client is null ', () => {
+            JSON.parse = jest.fn().mockImplementationOnce(() => {return client ;}).mockImplementationOnce(()=>{return null;});
+            callback();
+            expect(project.sendMessage).not.toHaveBeenCalled();
+            expect(mockRow.save).not.toHaveBeenCalled();
+        });
         it('should send a message containing the FO phone number to the Group leader phone number if the FO contact is available', () => {
             callback();
             expect(project.sendMessage).toHaveBeenCalledWith(expect.objectContaining({

--- a/client-registration/test.js
+++ b/client-registration/test.js
@@ -89,7 +89,7 @@ describe('clientRegistration', () => {
         it('should tell the client to confirm the national Id they have entered', () => {
             callback(nationalId);
             expect(sayText).toHaveBeenCalledWith(`You enter ${nationalId} ID`+
-            '. Enter 1 to confirm or 2 to try again');
+            '. Enter\n1) To confirm\n2) To try again');
         });
         it('should prompt for the client to confirm their national Id', () => {
             callback();
@@ -150,7 +150,7 @@ describe('clientRegistration', () => {
         it('should tell the client to confirm their phone number after they have entered it', () => {
             callback(phone);
             expect(sayText).toHaveBeenCalledWith(`You enter ${phone}`+
-            ' Phone number. Enter 1 to confirm or 2 to try again');
+            ' Phone number. Enter\n1) To confirm\n2) To try again');
         });
         it('should prompt to ask the user if the would like to be a GL', () => {
             callback(phone);
@@ -224,16 +224,16 @@ describe('clientRegistration', () => {
             callback();
             expect(mockTable.createRow).toHaveBeenCalledWith({
                 'contact_id': contact.id,
-                'from_number': contact.from_number,
                 'vars': {
                     'account_number': client.AccountNumber,
                     'national_id': client.NationalId,
-                    'phone_number': state.vars.phoneNumber,
+                    'client_phone_number': state.vars.phoneNumber,
                     'first_name': client.FirstName,
                     'last_name': client.LastName,
                     'district': client.DistrictId,
                     'site': client.SiteId,
                     'new_client': '1',
+                    'gl_phone_number': contact.phone_number,
                     'gl_interested': state.vars.groupLeader
                 }
             });

--- a/client-registration/translations.js
+++ b/client-registration/translations.js
@@ -5,8 +5,8 @@ module.exports = {
         'sw': 'Weka nambari ya kitambulisho ya mkulima?'
     },
     'confirm_national_id': {
-        'en-ke': 'You enter $nationalId ID. Enter 1 to confirm or 2 to try again',
-        'sw': 'Umeweka nambari ya kitambulisho $nationalId. Weka 1 kudhibitisha au 2 kujaribu tena'
+        'en-ke': 'You enter $nationalId ID. Enter\n1) To confirm\n2) To try again',
+        'sw': 'Umeweka nambari ya kitambulisho $nationalId. Weka\n1) kudhibitisha\n2) kujaribu tena'
 
     },
     'first_name_prompt': {
@@ -22,8 +22,8 @@ module.exports = {
         'sw': 'Weka nambari ya simu ya mkulima'
     },
     'confrm_phone_prompt': {
-        'en-ke': 'You enter $phone Phone number. Enter 1 to confirm or 2 to try again',
-        'sw': 'Umeweka nambari ya simu $phone . Weka 1 kudhibitisha au 2 kujaribu tena.'
+        'en-ke': 'You enter $phone Phone number. Enter\n1) To confirm\n2) To try again',
+        'sw': 'Umeweka nambari ya simu $phone . Weka\n1) kudhibitisha\n2) kujaribu tena.'
     },
     'invalid_national_id': {
         'en-ke': 'Invalid entry. Please enter a valid national id.',

--- a/ke-legacy/utils/menus/populate-menu/mainMenu.js
+++ b/ke-legacy/utils/menus/populate-menu/mainMenu.js
@@ -14,8 +14,8 @@ module.exports = [
         'start_date': project.vars.start_check_balance
     },
     {
-        'en-ke': 'Enroll',
-        'sw': 'Jisajili',
+        'en-ke': 'Register client',
+        'sw': 'Sajili Mkulima',
         'option_name': 'register_client',
         'end_date': project.vars.end_register_client,
         'start_date': project.vars.start_register_client

--- a/rw-legacy/lib/roster/register-client.js
+++ b/rw-legacy/lib/roster/register-client.js
@@ -61,7 +61,7 @@ module.exports = function (clientJSON, lang) {
             logResponse(fullUrl, response);
             if (response.content == "\"National Id Conflict\"") {
                 var msgs = require('../msg-retrieve');
-                sayText(msgs('ENR_NATIONAL_ID_DUPLICATE'), {}, lang);
+                sayText(msgs('enrolled_national_id'), {}, lang);
                 stopRules();
                 return null;
             }

--- a/rw-legacy/lib/roster/register-client.js
+++ b/rw-legacy/lib/roster/register-client.js
@@ -59,10 +59,11 @@ module.exports = function (clientJSON, lang) {
         }
         else if (response.status == 409) {
             logResponse(fullUrl, response);
-                var msgs = require('../msg-retrieve');
-                sayText(msgs('enrolled_national_id'), {'$AccountNumber': response.content}, lang);
-                stopRules();
-                return null;
+            var msgs = require('../msg-retrieve');
+            var accountNumber = parseInt(response.content.replace(/\"/g, " "));
+            sayText(msgs('enrolled_national_id', {'$AccountNumber': accountNumber}, lang));
+            stopRules();
+            return null;
         }
         else {
             logResponse(fullUrl, response);

--- a/rw-legacy/lib/roster/register-client.js
+++ b/rw-legacy/lib/roster/register-client.js
@@ -59,12 +59,10 @@ module.exports = function (clientJSON, lang) {
         }
         else if (response.status == 409) {
             logResponse(fullUrl, response);
-            if (response.content == "\"National Id Conflict\"") {
                 var msgs = require('../msg-retrieve');
-                sayText(msgs('enrolled_national_id'), {}, lang);
+                sayText(msgs('enrolled_national_id'), {'$AccountNumber': response.content}, lang);
                 stopRules();
                 return null;
-            }
         }
         else {
             logResponse(fullUrl, response);

--- a/rw-legacy/lib/utils/message-translations.js
+++ b/rw-legacy/lib/utils/message-translations.js
@@ -712,8 +712,10 @@ module.exports = {
         "ki": "Niyandikishije muri TUBURA nemeye amabwiriza n'amategeko agenga ideni rya TUBURA nkazayasinya kumunsi w'ifata ry'inyongeramusaruro. ~B 1) Gukomeza ~B 2)Gusohoka",
     },
     "FAILURE_REGISTERING": {
-        "en": "Registration failed. Please try again later",
-        "ki": "Kwiyandikisha biranze. Ongera mukanya",
+        'en': 'Registration failed. Please try again later',
+        'en-ke': 'Registration failed, Please try again later. At this time many people are using the system!',
+        'ki': 'Kwiyandikisha biranze. Ongera mukanya',
+        'sw': 'Tafadhali jaribu tena baada ya mda kidogo. Watu wengi wanatuma maombi kwa sasa!'
     },
     "ENR-SMS-ORDER-FINALIZE": {
         "en": "The total price is $TotalPrice for your $OrderDetails orders, don’t forget to make a prepayment by the 1st of July. Tubura is your trusted partner for quality products and quality harvests.",

--- a/rw-legacy/lib/utils/message-translations.js
+++ b/rw-legacy/lib/utils/message-translations.js
@@ -819,7 +819,8 @@ module.exports = {
         'ki': '$label) Reba amakuru y\'ubwishyu bwishyuwe mu itsinda\n'
     },
     'enrolled_national_id':{
-        'en-ke':'You have already enrolled this season and your account number is $AccountNumber. Reach out to your FO to help you add inputs to your order.',
-        'sw': 'Tayari umesajiliwa mwaka huu na akauti namba yako ni $AccountNumber Tembelea mwalimu wako ili akusaidie kuongeza bidhaa unazotaka!'
+        'en': 'Thank you for expressing your interest to enroll with OAF. Your Account Number is: $AccountNumber .Your FO will reach out to you to add inputs to your order.',
+        'en-ke': 'Thank you for expressing your interest to enroll with OAF. Your Account Number is: $AccountNumber .Your FO will reach out to you to add inputs to your order.',
+        'sw': 'Asante kwa nia ya kujiandikisha na OAF. Nambari yako ya akaunti ni: $AccountNumber. Mwalimu wa nyanjani atawasiliana na wewe ili uchagua bidhaa.'
     }
 }

--- a/rw-legacy/lib/utils/message-translations.js
+++ b/rw-legacy/lib/utils/message-translations.js
@@ -815,5 +815,9 @@ module.exports = {
     'view_group_repayment': {
         'en': '$label) View group repayment\n',
         'ki': '$label) Reba amakuru y\'ubwishyu bwishyuwe mu itsinda\n'
+    },
+    'enrolled_national_id':{
+        'en-ke':'You have already enrolled this season and your account number is $AccountNumber. Reach out to your FO to help you add inputs to your order.',
+        'sw': 'Tayari umesajiliwa mwaka huu na akauti namba yako ni $AccountNumber Tembelea mwalimu wako ili akusaidie kuongeza bidhaa unazotaka!'
     }
 }


### PR DESCRIPTION
…enaming,changed message for confirmations


SER-199 Update menu option name
- updated the option 3 on the main menu from 3)enrol to 3)register client (Swahili included)

SER-201 Update column names for phone numbers for registration service
- updated the phone numbers columns names to differentiate them. (client_phone_number and gl_phone_number)
 
SER-202 Change the format of the phone number and national ID confirmation service
- updated the confirmation message to have a more user-friendly format

SER-200 Updated the duplicate national Id message on the server response side. 

Link for testing: https://telerivet.com/p/0c6396c9/service/SVb47209de1fdd2cf0/edit

Steps to test: 
- enter as account number **24450523**
- choose option 3 (should now be register client or Sajili Mkulima)
- Enter zero
- Enter a duplicate id: **28785463 ** or a valid one (any 8 digits number)
- Enter and names (first and last)
- Enter a phone number: 0712301351
- Choose one or 1 for GL 
if you chose a duplicate ID you should receive a message with your account number
else if you chose a valid ID, a row should be created with the client_phone number and the gl_phone_number fields in 'dev_lr_2021_client_table'

