### PR TITLE
Fixing duka locator

### DIFF
--- a/duka-locator/inputHandlers/dukaHandler.js
+++ b/duka-locator/inputHandlers/dukaHandler.js
@@ -13,7 +13,7 @@ module.exports = function dukaHandler(input) {
     if(dukasTableEntries.hasNext()) {
         var record = dukasTableEntries.next().vars;
         state.vars.selected_duka = JSON.stringify(record);
-        var dukaLocation = record[lang];
+        var dukaLocation = record[lang === 'sw' ? lang : 'en'];
         state.vars.duka_options = JSON.stringify({reach_out_to_agent: 1, exit_menu: 2});
         var menu = getMessage('reach_out_to_agent', {'$label': 1}, lang) + getMessage('exit_menu', {'$label': 2}, lang);
         sayText(dukaLocation + '\n' + menu);

--- a/duka-locator/translations/index.js
+++ b/duka-locator/translations/index.js
@@ -1,50 +1,62 @@
 var translations = {
     'select_oaf_duka_region': {
         en: 'To find a One Acre Fund Duka near you, select region\n$Menu',
+        'en-ke': 'To find a One Acre Fund Duka near you, select region\n$Menu',
         sw: 'Kulipata Duka la One Acre Fund karibu nawe,Chagua eneo lako\n$Menu'
     },
     'select_oaf_duka_county': {
         en: 'Please select your county\n$Menu\n',
+        'en-ke': 'Please select your county\n$Menu\n',
         sw: 'Tafadhali chagua county yako\n$Menu\n'
     },
     'select_oaf_duka': {
         en: 'Please select your duka\n$Menu',
+        'en-ke': 'Please select your duka\n$Menu',
         sw: 'Tafadhali chagua duka lako\n$Menu'
     },
     'unlisted_region': {
         en: '$label) My region is not listed\n',
+        'en-ke': '$label) My region is not listed\n',
         sw: '$label) Eneo langu halijaorodheshwa\n'
     },
     'reach_out_to_agent': {
         en: '$label) Reach out to a duka agent.\n',
+        'en-ke': '$label) Reach out to a duka agent.\n',
         sw: '$label) Ongea na muhudumu wetu.\n'
     },
     'exit_menu': {
         en: '$label) Exit menu\n',
+        'en-ke': '$label) Exit menu\n',
         sw: '$label) Hapana- Exit Menu\n'
     },
     'message_to_duka_supervisor': {
         en: 'There is a potential client with phonenumber $client_pn. Please call them back to follow up. Thanks',
+        'en-ke': 'There is a potential client with phonenumber $client_pn. Please call them back to follow up. Thanks',
         sw: 'Kuna mteja kwa nambari ya simu $client_pn. Tafdhali mpigie simu ili umuhudumie. Asante'
     },
     'message_to_farmer': {
         en: '$duka_supervisor_name is your One Acre Fund contact person. Their number is $duka_supervisor_pn',
+        'en-ke': '$duka_supervisor_name is your One Acre Fund contact person. Their number is $duka_supervisor_pn',
         sw: '$duka_supervisor_name ndiye muhudumu wa One Acre Fund Duka lako. Nambari yake ya simu ni $duka_supervisor_pn'
     },
     'supported_locations': {
         en: 'Sorry, OAF currently has OAF Dukas in the following locations\n$Locations',
+        'en-ke': 'Sorry, OAF currently has OAF Dukas in the following locations\n$Locations',
         sw: 'Pole,kwa sasa OAF ina maduka maeneo yafuatayo\n$Locations'
     },
     'invalid_input': {
         en: 'Invalid input\n$Menu',
+        'en-ke': 'Invalid input\n$Menu',
         sw: 'Nambari sio sahihi\n$Menu'
     },
     'change_lang': {
         en: '99) Swahili',
+        'en-ke': '99) Swahili',
         sw: '99) English'
     },
     'next_page': {
         en: '* Next',
+        'en-ke': '* Next',
         sw: '* Endelea'
     }
 };


### PR DESCRIPTION
Fixing duka locator -KENYA
[Old implementation](https://telerivet.com/p/0c6396c9/service/SVbc04709b5abb48c0)
- After selecting the duka, you are prompted to whether to reach out to the duka agent(which is sending them a message). This screen has a title which is supposed to be the address of the selected duka. However, it now display undefined due to the collision of language 'en' and 'en-ke'.

[New implementation](https://telerivet.com/p/0c6396c9/service/SV7684c662f118f82e/edit)
- Dial the short code
- enter the account number (**26215997**)
- select Locate OAF Duka (option 10 on screen 2)
- go through the process until you reach the dukas.
- select one of the listed dukas
- there should come a screen asking you whether to reach out to that duka's agent.
This screen should have a title being the location address of that duka instead of **undefined**