### PR TITLE
added the first menu for just in time

### DIFF
--- a/just-in-time/account-number-handler/accountNumberHandler.js
+++ b/just-in-time/account-number-handler/accountNumberHandler.js
@@ -1,0 +1,34 @@
+var handlerName = 'account_number_handler';
+var translations = require('../translations');
+var createTranslator = require('../../utils/translator/translator');
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+var rosterAPI = require('../../rw-legacy/lib/roster/api');
+var translate =  createTranslator(translations, project.vars.lang);
+
+
+var isInTheSameGroup = function(accountNumber) {
+    var clientJSON = rosterAPI.getClient(accountNumber,state.vars.country);
+    if(clientJSON){
+        state.vars.topUpClient = JSON.stringify(clientJSON);
+        var groupId = clientJSON.GroupId;
+        if(JSON.parse(state.vars.client_json).GroupId == groupId){
+            return true;
+        }
+        return false;
+    }
+};
+module.exports = {
+    handlerName: handlerName,
+    getHandler: function(onAccountNumberValidated){
+        return function (input) {
+            notifyELK();
+            if(isInTheSameGroup(input)){
+                onAccountNumberValidated();
+            }
+            else{
+                global.sayText(translate('account_number_handler',{},state.vars.jitLang));
+                global.promptDigits(handlerName);
+            }
+        };
+    }
+};

--- a/just-in-time/account-number-handler/accountNumberHandler.js
+++ b/just-in-time/account-number-handler/accountNumberHandler.js
@@ -7,15 +7,20 @@ var translate =  createTranslator(translations, project.vars.lang);
 
 
 var isInTheSameGroup = function(accountNumber) {
-    var clientJSON = rosterAPI.getClient(accountNumber,state.vars.country);
-    if(clientJSON){
-        state.vars.topUpClient = JSON.stringify(clientJSON);
-        var groupId = clientJSON.GroupId;
-        if(JSON.parse(state.vars.client_json).GroupId == groupId){
-            return true;
+    
+    if(rosterAPI.authClient(accountNumber,'KE')){
+        var clientJSON = rosterAPI.getClient(accountNumber,state.vars.country);
+        if(clientJSON){
+            state.vars.topUpClient = JSON.stringify(clientJSON);
+            var groupId = clientJSON.GroupId;
+            if(JSON.parse(state.vars.client_json).GroupId == groupId){
+                return true;
+            }
+            return false;
         }
-        return false;
+
     }
+    return false;
 };
 module.exports = {
     handlerName: handlerName,

--- a/just-in-time/account-number-handler/accountNumberHandler.test.js
+++ b/just-in-time/account-number-handler/accountNumberHandler.test.js
@@ -1,0 +1,55 @@
+const {handlerName, getHandler} = require ('./accountNumberHandler');
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+var rosterAPI = require('../../rw-legacy/lib/roster/api');
+var {client} = require('../../client-enrollment/test-client-data');
+var secondClient = require('../test-client-data');
+jest.mock('../../rw-legacy/lib/roster/api');
+jest.mock('../../notifications/elk-notification/elkNotification');
+describe('account_number_handler', () => {
+    var accountNumberHandler;
+    var onAccountNumberValidated;
+    var validAccountNumber = '123456789';
+    var accountNumberDifferentGroup = '24450523';
+    beforeEach(() => {
+        sayText.mockReset();
+        onAccountNumberValidated = jest.fn();
+        accountNumberHandler = getHandler(onAccountNumberValidated);
+        rosterAPI.getClient = jest.fn();
+        state.vars.country = 'KE';
+        state.vars.jitLang = 'en-ke';
+        state.vars.client_json = JSON.stringify(client);
+    });
+    it('should call notifyELK ', () => {
+        accountNumberHandler(validAccountNumber);
+        expect(notifyELK).toHaveBeenCalled();
+    });
+    it('should  call onAccountNumberValidated if the provided account number is validated from roster and is in a the same group than as the GL', () => {
+        rosterAPI.getClient.mockReturnValueOnce(client);
+        accountNumberHandler(validAccountNumber);
+        expect(onAccountNumberValidated).toHaveBeenCalled();
+    });
+    it('should not call onAccountNumberValidated if the provided account number is not valid from roster', () => {
+        rosterAPI.getClient.mockReturnValueOnce(false);
+        accountNumberHandler(1234);
+        expect(onAccountNumberValidated).not.toHaveBeenCalled();
+    });
+    it('should not call onAccountNumberValidated if the provided account number is valid but is not in the same group as the one of GL', () => {
+        rosterAPI.getClient.mockReturnValueOnce(client);
+        state.vars.client_json = JSON.stringify(secondClient);
+        accountNumberHandler(1234);
+        expect(onAccountNumberValidated).not.toHaveBeenCalled();
+    });
+    it('should prompt for retry if input is not a valid acount number from roster', () => {
+        rosterAPI.getClient.mockReturnValueOnce(false);
+        accountNumberHandler(1234);
+        expect(sayText).toHaveBeenCalledWith('Please reply with the account number of the farmer who want to top-up.');
+        expect(promptDigits).toHaveBeenCalledWith(handlerName);
+    });
+    it('should prompt for retry if input is not valid account number from roster but in a different group from the group leader\'s', () => {
+        rosterAPI.getClient.mockReturnValueOnce(client);
+        state.vars.client_json = JSON.stringify(secondClient);
+        accountNumberHandler(accountNumberDifferentGroup);
+        expect(sayText).toHaveBeenCalledWith('Please reply with the account number of the farmer who want to top-up.');
+        expect(promptDigits).toHaveBeenCalledWith(handlerName);
+    });
+});

--- a/just-in-time/account-number-handler/accountNumberHandler.test.js
+++ b/just-in-time/account-number-handler/accountNumberHandler.test.js
@@ -10,6 +10,10 @@ describe('account_number_handler', () => {
     var onAccountNumberValidated;
     var validAccountNumber = '123456789';
     var accountNumberDifferentGroup = '24450523';
+    beforeAll(()=>{
+        rosterAPI.authClient = jest.fn();
+        rosterAPI.authClient.mockReturnValue(true);
+    });
     beforeEach(() => {
         sayText.mockReset();
         onAccountNumberValidated = jest.fn();

--- a/just-in-time/justInTime.js
+++ b/just-in-time/justInTime.js
@@ -6,19 +6,6 @@ var notifyELK = require('../notifications/elk-notification/elkNotification');
 var translate =  createTranslator(translations, project.vars.lang);
 module.exports = {
     registerHandlers: function (){
-        
-        function onAccountNumberValidated(){
-            var client = JSON.parse(state.vars.topUpClient);
-            var remainingLoan = 0;
-            if(client.BalanceHistory.length > 0){
-                client.latestBalanceHistory = client.BalanceHistory[0];
-                remainingLoan = client.latestBalanceHistory.TotalCredit - client.latestBalanceHistory.TotalRepayment_IncludingOverpayments;
-            }
-            if(remainingLoan > 500 ){
-                var amountToPay = remainingLoan-500;
-                global.sayText(translate('loan_payment_not_satisfied',{'$amount': amountToPay },state.vars.jitLang));
-            }
-        }
         addInputHandler(accountNumberHandler.handlerName, accountNumberHandler.getHandler(onAccountNumberValidated));
     },
 
@@ -32,3 +19,16 @@ module.exports = {
         global.promptDigits(accountNumberHandler.handlerName);
     }
 };
+
+function onAccountNumberValidated(){
+    var client = JSON.parse(state.vars.topUpClient);
+    var remainingLoan = 0;
+    if(client.BalanceHistory.length > 0){
+        client.latestBalanceHistory = client.BalanceHistory[0];
+        remainingLoan = client.latestBalanceHistory.TotalCredit - client.latestBalanceHistory.TotalRepayment_IncludingOverpayments;
+    }
+    if(remainingLoan > 500 ){
+        var amountToPay = remainingLoan-500;
+        global.sayText(translate('loan_payment_not_satisfied',{'$amount': amountToPay },state.vars.jitLang));
+    }
+}

--- a/just-in-time/justInTime.js
+++ b/just-in-time/justInTime.js
@@ -1,0 +1,34 @@
+
+var translations = require('./translations');
+var createTranslator = require('../utils/translator/translator');
+var accountNumberHandler = require('./account-number-handler/accountNumberHandler');
+var notifyELK = require('../notifications/elk-notification/elkNotification');
+var translate =  createTranslator(translations, project.vars.lang);
+module.exports = {
+    registerHandlers: function (){
+        
+        function onAccountNumberValidated(){
+            var client = JSON.parse(state.vars.topUpClient);
+            var remainingLoan = 0;
+            if(client.BalanceHistory.length > 0){
+                client.latestBalanceHistory = client.BalanceHistory[0];
+                remainingLoan = client.latestBalanceHistory.TotalCredit - client.latestBalanceHistory.TotalRepayment_IncludingOverpayments;
+            }
+            if(remainingLoan > 500 ){
+                var amountToPay = remainingLoan-500;
+                global.sayText(translate('loan_payment_not_satisfied',{'$amount': amountToPay },state.vars.jitLang));
+            }
+        }
+        addInputHandler(accountNumberHandler.handlerName, accountNumberHandler.getHandler(onAccountNumberValidated));
+    },
+
+    start: function (account, country,lang) {
+        notifyELK();
+        state.vars.account = account;
+        state.vars.country = country;
+        state.vars.jitLang = lang;
+        var translate =  createTranslator(translations, state.vars.jitLang);
+        global.sayText(translate('account_number_handler',{},state.vars.jitLang));
+        global.promptDigits(accountNumberHandler.handlerName);
+    }
+};

--- a/just-in-time/justInTime.test.js
+++ b/just-in-time/justInTime.test.js
@@ -1,0 +1,76 @@
+const accountNumberHandler = require('./account-number-handler/accountNumberHandler');
+const justInTime = require('./justInTime');
+var {client}  = require('../client-enrollment/test-client-data');
+var notifyELK = require('../notifications/elk-notification/elkNotification');
+
+jest.mock('../notifications/elk-notification/elkNotification');
+jest.mock('./account-number-handler/accountNumberHandler');
+
+const mockAccountNumberHandler = jest.fn();
+
+const account = 123456789;
+const country = 'KE';
+const jitLang = 'en-ke';
+
+describe('clientRegistration', () => {
+
+    it('should have a start function', () => {
+        expect(justInTime.start).toBeInstanceOf(Function);
+    });
+    beforeAll(()=>{
+        state.vars.jitLang = jitLang;
+        state.vars.topUpClient = JSON.stringify(client);
+    });
+    beforeEach(() => {
+        accountNumberHandler.getHandler.mockReturnValue(mockAccountNumberHandler);
+
+    });
+    it('should add the account number handler to input handlers', () => {
+        justInTime.registerHandlers();
+        expect(addInputHandler).toHaveBeenCalledWith(accountNumberHandler.handlerName, accountNumberHandler.getHandler());            
+    });
+    describe('Account number handler success callback', () => {
+        var callback;
+        beforeEach(() => {
+            justInTime.registerHandlers();
+            callback = accountNumberHandler.getHandler.mock.calls[0][0];                
+        });
+        it('should not display a message saying that the prepayment is not one if the prepayment consition is not met',()=>{
+            callback();
+            expect(sayText).not.toHaveBeenCalledWith(expect.stringContaining('You do not qualify for a top up,'));
+        });
+        it('should display a message saying that the prepayment condition is not satified if the remaining loan is greater than 500', () => {
+            client.BalanceHistory[0].TotalCredit = 5000;
+            client.BalanceHistory[0].TotalRepayment_IncludingOverpayments = 0;
+            var amount = 4500;
+            state.vars.topUpClient = JSON.stringify(client);
+            callback();
+            expect(sayText).toHaveBeenCalledWith(`You do not qualify for a top up, pay at least ${amount}`+
+            ' to qualify.');
+        });
+    });
+
+    describe('start', () => {
+        it('should set the  state vars to match the provided account and country', () => {
+            state.vars.account = '';
+            state.vars.country = '';
+            state.vars.jitLang = '';
+            justInTime.start(account, country,jitLang);
+            expect(state.vars).toMatchObject({account,country,jitLang});
+        });
+        it('should call notifyELK', () => {
+            justInTime.start(account, country,jitLang);
+            expect(notifyELK).toHaveBeenCalled();
+        });
+        it('should show a message asking for the account number for the farmer to top up', () => {
+            justInTime.start(account, country, jitLang);
+            expect(sayText).toHaveBeenCalledWith('Please reply with the account number of the farmer who want to top-up.');
+            expect(sayText).toHaveBeenCalledTimes(1);
+        });
+        it('should prompt for the account number for the farmer to top up', () => {
+            justInTime.start(account, country, jitLang);
+            expect(promptDigits).toHaveBeenCalledWith(accountNumberHandler.handlerName);
+            expect(promptDigits).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/just-in-time/test-client-data.js
+++ b/just-in-time/test-client-data.js
@@ -1,0 +1,68 @@
+module.exports = {
+    'GlobalClientId': 'f456ff55-2d01-ea21-a42d-505bc2b76563',
+    'AccountNumber': '123456789',
+    'ClientName': 'TCHALLA, PRINCE',
+    'FirstName': 'PRINCE',
+    'LastName': 'TCHALLA',
+    'CreatedDate': '2019-11-12T12:18:00.557',
+    'EnrollmentDate': '2019-11-12T12:18:00.557',
+    'BannedDate': null,
+    'DeceasedDate': null,
+    'EarliestCreatedDate': '2019-11-12T12:18:00.557',
+    'EarliestEnrollmentDate': '2019-11-12T12:18:00.557',
+    'LatestBannedDate': null,
+    'ClientId': 7201,
+    'GroupId': 1,
+    'GroupName': 'BIKUWERAKI',
+    'SiteId': 22,
+    'SiteName': 'Mafubira Buwekula',
+    'DistrictId': 2800,
+    'DistrictName': 'Jinja',
+    'RegionId': 1800,
+    'RegionName': 'South East',
+    'CountryId': 800,
+    'CountryName': 'Uganda',
+    'AccountHistory': [{
+        'AccountGuid': 'f456ff55-2d01-ea21-a42d-505bc2b76563',
+        'ClientId': 7201,
+        'AccountNumber': '123456789',
+        'DistrictId': 2800,
+        'DistrictName': 'Jinja',
+        'RegionId': 1800,
+        'RegionName': 'South East',
+        'CountryId': 800,
+        'CountryName': 'Uganda'
+    }
+    ],
+    'BalanceHistory': [
+        {
+            'AccountGuid': 'f456ff55-2d01-ea21-a42d-505bc2b76563',
+            'GroupId': 678,
+            'GroupName': 'BIKUWERAKI',
+            'SiteId': 22,
+            'SiteName': 'Mafubira Buwekula',
+            'SeasonId': 270,
+            'SeasonName': '2020, Short Rain',
+            'SeasonStart': '2020-08-01T00:00:00',
+            'TotalCredit': 1280.000,
+            'TotalRepayment_IncludingOverpayments': 1500.000,
+            'Balance': 128000.0000,
+            'CurrencyCode': 'UGX'
+        },
+        {
+            'AccountGuid': 'f456ff55-2d01-ea21-a42d-505bc2b76563',
+            'GroupId': 678,
+            'GroupName': 'BIKUWERAKI',
+            'SiteId': 22,
+            'SiteName': 'Mafubira Buwekula',
+            'SeasonId': 260,
+            'SeasonName': '2020, Long Rain',
+            'SeasonStart': '2020-03-01T00:00:00',
+            'TotalCredit': 164000.000,
+            'TotalRepayment_IncludingOverpayments': 147000.0000,
+            'Balance': 17000.0000,
+            'CurrencyCode': 'UGX'
+        }
+    ]
+    
+};

--- a/just-in-time/translations.js
+++ b/just-in-time/translations.js
@@ -1,0 +1,11 @@
+
+module.exports = {
+    'account_number_handler': {
+        'en-ke': 'Please reply with the account number of the farmer who want to top-up.',
+        'sw': 'Tafadhali jibu na nambari ya akaunti ya mkulima anayetaka kuongeza bidhaa.'
+    },
+    'loan_payment_not_satisfied': {
+        'en-ke': 'You do not qualify for a top up, pay at least $amount to qualify.',
+        'sw': 'Bado haujahitimu kuongeza bidhaa, lipa $amount  kuhitimu.'
+    }
+};

--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -17,10 +17,14 @@ service.vars.server_name = project.vars[env+'_server_name'];
 service.vars.roster_api_key = project.vars[env+'_roster_api_key'];
 service.vars.currency = 'KES';
 
+service.vars.topUpStart = env + '_start_top_up';
+service.vars.topUpEnd = env + '_end_top_up';
+
 var notifyELK = require('../notifications/elk-notification/elkNotification');
 var transactionHistory = require('../transaction-history/transactionHistory');
 var clientRegistration = require('../client-registration/clientRegistration');
 var clientEnrollment = require('../client-enrollment/clientEnrollment');
+var justInTime = require('../just-in-time/justInTime');
 // Setting global variables!
 var translations = require('./translations/index');
 var createTranslator = require('../utils/translator/translator');
@@ -1653,6 +1657,7 @@ global.main = function () {
 dukaLocator.registerDukaLocatorHandlers({lang: GetLang() ? 'en' : 'sw'});
 transactionHistory.registerHandlers();
 clientRegistration.registerHandlers();
+justInTime.registerHandlers();
 groupRepaymentsModule.registerGroupRepaymentHandlers({lang: GetLang() ? 'en' : 'sw', main_menu: state.vars.main_menu, main_menu_handler: 'MainMenu'});
 
 addInputHandler('SplashMenu', function(SplashMenu) {
@@ -1782,6 +1787,9 @@ addInputHandler('MainMenu', function(SplashMenu){
     else if(sessionMenu[SplashMenu-1].option_name == 'register_client'){
         registrationMenu();
         promptDigits("registrationHandler", {submitOnHash: true, maxDigits: 10, timeout: 5});
+    }
+    else if(sessionMenu[SplashMenu-1].option_name == 'top_up'){
+        justInTime.start(client.AccountNumber, 'KE',state.vars.lang);
     }
     else if(sessionMenu[SplashMenu-1].option_name == 'trainings'){
         TrainingMenuText();

--- a/ke-legacy/utils/menus/populate-menu/mainMenu.js
+++ b/ke-legacy/utils/menus/populate-menu/mainMenu.js
@@ -19,6 +19,13 @@ module.exports = [
         'option_name': 'register_client',
         'end_date': project.vars.end_register_client,
         'start_date': project.vars.start_register_client
+    },{
+        'en-ke': 'Top up',
+        'sw': 'Ongeza Bibhaa',
+        'option_name': 'top_up',
+        'end_date': project.vars[service.vars.topUpEnd],
+        'start_date': project.vars[service.vars.topUpStart]
+
     },
     {
         'en-ke': 'Training',

--- a/ke-legacy/utils/menus/populate-menu/populateMenu.js
+++ b/ke-legacy/utils/menus/populate-menu/populateMenu.js
@@ -58,6 +58,11 @@ var skipMenuOption = function(optionName){
             return true;
         }
     }
+    else if(optionName == 'top_up'){
+        if(!state.vars.isGroupLeader){
+            return true;
+        }
+    }
     return false;
 }
 


### PR DESCRIPTION
As a GL, I want to be able to top up a client's order via USSD, so that I can adjust orders prior to distribution (PART 1)

The first menu that deals with checking if the client is a group leader and that he wants to top up for a valid account number in their group.

Link for testing: https://telerivet.com/p/0c6396c9/service/SVb47209de1fdd2cf0/edit

Steps:

Log in with the account number: 24450523
Should see option 4(top Up)-- choose it

**Enter an account number in the same group**
- 24450523 (should see a message saying how much they need to pay)
- use 26965613 for another account number in the same group

**Repeat the same process with an account number, not in the same group**
- use 16532926. should prompt the user for an account number in the same group