### PR TITLE
hot fix: fixing tester pack confirmation

### DIFF
--- a/tester-pack/confirmation/inputHandlers/cellHandler.js
+++ b/tester-pack/confirmation/inputHandlers/cellHandler.js
@@ -39,7 +39,7 @@ module.exports = function cellHandler(input) {
             maxDigits: 2,
             submitOnHash: false
         });
-    } else if(input === '*' && cells_screens[current_cells_screen + 1]) {
+    } else if(input == 77 && cells_screens[current_cells_screen + 1]) {
         state.vars.current_cells_screen = current_cells_screen + 1;
         sayText(cells_screens[state.vars.current_cells_screen]);
         promptDigits('select_cell', {

--- a/tester-pack/confirmation/inputHandlers/cellHandler.test.js
+++ b/tester-pack/confirmation/inputHandlers/cellHandler.test.js
@@ -21,7 +21,7 @@ describe('Cell handler', () => {
 
     it('should prompt the user to select a village once the input matches a stored cell', () => {
         state.vars.cells = JSON.stringify({'1': 'Kora', '2': 'Kigarama', '3': 'Kabahizi'});
-        state.vars.cells_screens = JSON.stringify({'1': '1) Kora\n2) Kigarama\n* Komeza', '2': '3) Kabahizi'});
+        state.vars.cells_screens = JSON.stringify({'1': '1) Kora\n2) Kigarama\n77) Komeza', '2': '3) Kabahizi'});
         state.vars.current_cells_screen = 1;
 
         state.vars.provence = 2;
@@ -52,12 +52,12 @@ describe('Cell handler', () => {
         expect(promptDigits).toHaveBeenCalledWith('select_village', {'maxDigits': 2, 'submitOnHash': false, 'timeout': 5});
     });
 
-    it('should take the user to the next screen upon input of *', () => {
+    it('should take the user to the next screen upon input of 77', () => {
         state.vars.cells = JSON.stringify({'1': 'Kora', '2': 'Kigarama', '3': 'Kabahizi'});
-        state.vars.cells_screens = JSON.stringify({'1': '1) Kora\n2) Kigarama\n* Komeza', '2': '3) Kabahizi'});
+        state.vars.cells_screens = JSON.stringify({'1': '1) Kora\n2) Kigarama\n77) Komeza', '2': '3) Kabahizi'});
         state.vars.current_cells_screen = 1;
         project.getOrCreateDataTable = jest.fn();
-        cellHandler('*');
+        cellHandler(77);
         expect(state.vars.current_cells_screen).toEqual(2);
         expect(sayText).toHaveBeenCalledWith('3) Kabahizi');
         expect(promptDigits).toHaveBeenCalledWith('select_cell', {'maxDigits': 2, 'submitOnHash': false, 'timeout': 5});
@@ -65,7 +65,7 @@ describe('Cell handler', () => {
 
     it('should ask the user to retry when their input does\'t match any cell', () => {
         state.vars.cells = JSON.stringify({'1': 'Kora', '2': 'Kigarama', '3': 'Kabahizi'});
-        state.vars.cells_screens = JSON.stringify({'1': '1) Kora\n2) Kigarama\n* Komeza', '2': '3) Kabahizi'});
+        state.vars.cells_screens = JSON.stringify({'1': '1) Kora\n2) Kigarama\n77) Komeza', '2': '3) Kabahizi'});
         state.vars.current_cells_screen = 2;
         cellHandler('@');
         expect(state.vars.current_cells_screen).toEqual(2);

--- a/tester-pack/confirmation/inputHandlers/districtHandler.test.js
+++ b/tester-pack/confirmation/inputHandlers/districtHandler.test.js
@@ -23,7 +23,7 @@ describe('Districts handler', () => {
 
     it('should prompt a user to select a sector from a list of sectors that belongs to a selected district', () => {
         state.vars.districts = JSON.stringify({'1': 'Nyarugenge'});
-        state.vars.districts_screens = JSON.stringify({'1': '1) Nyarugenge\n2) Gasabo\n* Komeza', '2': '3) Kicukiro'}); 
+        state.vars.districts_screens = JSON.stringify({'1': '1) Nyarugenge\n2) Gasabo\n77) Komeza', '2': '3) Kicukiro'}); 
         state.vars.selected_province = 1; 
         const cursor = {queryRows: () => table_cursor};
         jest.spyOn(cursor, 'queryRows');
@@ -46,12 +46,12 @@ describe('Districts handler', () => {
         expect(promptDigits).toHaveBeenCalledWith('select_sector', {'maxDigits': 2, 'submitOnHash': false, 'timeout': 5});
     });
 
-    it('should display a next page of districts when available and user selects *', () => {
+    it('should display a next page of districts when available and user selects 77', () => {
         state.vars.districts = JSON.stringify({'1': 'Nyarugenge'});
-        state.vars.districts_screens = JSON.stringify({'1': '1) Nyarugenge\n2) Gasabo\n* Komeza', '2': '3) Kicukiro'});
+        state.vars.districts_screens = JSON.stringify({'1': '1) Nyarugenge\n2) Gasabo\n77) Komeza', '2': '3) Kicukiro'});
         state.vars.current_districts_screen = 1;
         project.getOrCreateDataTable = jest.fn();
-        districtHandler('*');
+        districtHandler('77');
         expect(state.vars.current_districts_screen).toEqual(2);
         expect(sayText).toHaveBeenCalledWith('3) Kicukiro');
         expect(promptDigits).toHaveBeenCalledWith('select_district', {'maxDigits': 2, 'submitOnHash': false, 'timeout': 5});
@@ -59,7 +59,7 @@ describe('Districts handler', () => {
 
     it('should prompt a user for a retry when their input doesn\'t match any district', () => {
         state.vars.districts = JSON.stringify({'1': 'Nyarugenge'});
-        state.vars.districts_screens = JSON.stringify({'1': '1) Nyarugenge\n2) Gasabo\n* Komeza', '2': '3) Kicukiro'});
+        state.vars.districts_screens = JSON.stringify({'1': '1) Nyarugenge\n2) Gasabo\n77) Komeza', '2': '3) Kicukiro'});
         state.vars.current_districts_screen = 2;
         districtHandler('@');
         expect(sayText).toHaveBeenCalledWith('Invalid input. Try again\n3) Kicukiro');

--- a/tester-pack/confirmation/inputHandlers/districtsHandler.js
+++ b/tester-pack/confirmation/inputHandlers/districtsHandler.js
@@ -32,7 +32,7 @@ module.exports = function districtHandler(input) {
             maxDigits: 2,
             submitOnHash: false
         });
-    } else if(input === '*' && districts_screens[current_districts_screen +1]) {
+    } else if(input == 77 && districts_screens[current_districts_screen +1]) {
         state.vars.current_districts_screen = current_districts_screen + 1;
         sayText(districts_screens[state.vars.current_districts_screen]);
         promptDigits('select_district', {

--- a/tester-pack/confirmation/inputHandlers/farmerHandler.js
+++ b/tester-pack/confirmation/inputHandlers/farmerHandler.js
@@ -17,7 +17,7 @@ module.exports = function farmerHandler(input) {
             maxDigits: 4,
             submitOnHash: false
         });
-    } else if(input === '*' && farmers_screens[state.vars.current_farmers_screen + 1]) {
+    } else if(input == 77 && farmers_screens[state.vars.current_farmers_screen + 1]) {
         state.vars.current_farmers_screen = state.vars.current_farmers_screen + 1;
         sayText(farmers_screens[state.vars.current_farmers_screen]); 
         promptDigits('select_farmer', {

--- a/tester-pack/confirmation/inputHandlers/farmerHandler.test.js
+++ b/tester-pack/confirmation/inputHandlers/farmerHandler.test.js
@@ -14,7 +14,7 @@ describe('Farmer handler', () => {
 
     it('should ask the user for their last 4 nid digits once they select a farmer', () => {
         state.vars.farmers = JSON.stringify({'1': {national_id: '13753675', id: 1, first_name: 'Mosh', last_name: 'Hamedani' }});
-        state.vars.farmers_screens = JSON.stringify({'1': '1) Mosh Hamedani\n2) Brad Traversy\n* Komeza', '2': '3) Fun Function'});
+        state.vars.farmers_screens = JSON.stringify({'1': '1) Mosh Hamedani\n2) Brad Traversy\n77) Komeza', '2': '3) Fun Function'});
         state.vars.current_cells_screen = 1;
         farmerHandler(1);
         expect(state.vars.selected_farmer).toEqual('{"national_id":"13753675","id":1,"first_name":"Mosh","last_name":"Hamedani"}');
@@ -22,9 +22,9 @@ describe('Farmer handler', () => {
         expect(sayText).toHaveBeenCalledWith('Please enter the last four digits of the national ID you registered with.');
         expect(promptDigits).toHaveBeenCalledWith('last_four_nid_digits', {'maxDigits': 4, 'submitOnHash': false, 'timeout': 10});
     });
-    it('should display a next screen if the user selects *', () => {
+    it('should display a next screen if the user selects 77', () => {
         state.vars.current_farmers_screen = 1;
-        farmerHandler('*');
+        farmerHandler('77');
         expect(state.vars.current_farmers_screen).toEqual(2);
         expect(sayText).toHaveBeenCalledWith('3) Fun Function');
         expect(promptDigits).toHaveBeenCalledWith('select_farmer', {'maxDigits': 2, 'submitOnHash': false, 'timeout': 5});

--- a/tester-pack/confirmation/inputHandlers/sectorsHandler.js
+++ b/tester-pack/confirmation/inputHandlers/sectorsHandler.js
@@ -10,7 +10,6 @@ module.exports = function sectorHandler(input) {
     var sector = sectors[input];
     var sectors_screens = JSON.parse(state.vars.sectors_screens);
     var current_sectors_screen = state.vars.current_sectors_screen;
-    console.log('>>>> sectors' + state.vars.sectors_screens + 'current screen' + state.vars.current_sectors_screen);
     if(sector) {
         state.vars.selected_sector = sector;
         var cells = {};
@@ -38,7 +37,7 @@ module.exports = function sectorHandler(input) {
             maxDigits: 2,
             submitOnHash: false
         });
-    } else if(input === '*' && sectors_screens[current_sectors_screen + 1]) {
+    } else if(input == 77 && sectors_screens[current_sectors_screen + 1]) {
         state.vars.current_sectors_screen = current_sectors_screen + 1;
         sayText(sectors_screens[state.vars.current_sectors_screen]);
         promptDigits('select_sector', {

--- a/tester-pack/confirmation/inputHandlers/sectorsHandler.js
+++ b/tester-pack/confirmation/inputHandlers/sectorsHandler.js
@@ -10,6 +10,7 @@ module.exports = function sectorHandler(input) {
     var sector = sectors[input];
     var sectors_screens = JSON.parse(state.vars.sectors_screens);
     var current_sectors_screen = state.vars.current_sectors_screen;
+    console.log('>>>> sectors' + state.vars.sectors_screens + 'current screen' + state.vars.current_sectors_screen);
     if(sector) {
         state.vars.selected_sector = sector;
         var cells = {};

--- a/tester-pack/confirmation/inputHandlers/sectorsHandler.test.js
+++ b/tester-pack/confirmation/inputHandlers/sectorsHandler.test.js
@@ -21,7 +21,7 @@ describe('Sectors handler', () => {
 
     it('should prompt a user for a cell when their input matches a stored sector', () => {
         state.vars.sectors = JSON.stringify({'1': 'Gitega', '2': 'Cyahafi', '3': 'Nyamirambo'});
-        state.vars.sectors_screens = JSON.stringify({'1': '1) Gitega\n2) Cyahafi\n* Komeza', '2': '3) Nyamirambo'});
+        state.vars.sectors_screens = JSON.stringify({'1': '1) Gitega\n2) Cyahafi\n77) Komeza', '2': '3) Nyamirambo'});
         state.vars.selected_provence = 2;
         state.vars.selected_district = 1;
         const cursor = {queryRows: () => table_cursor};
@@ -49,10 +49,10 @@ describe('Sectors handler', () => {
 
     it('should handle the option for next screen', () => {
         state.vars.sectors = JSON.stringify({'1': 'Gitega', '2': 'Cyahafi', '3': 'Nyamirambo'});
-        state.vars.sectors_screens = JSON.stringify({'1': '1) Gitega\n2) Cyahafi\n* Komeza', '2': '3) Nyamirambo'});
+        state.vars.sectors_screens = JSON.stringify({'1': '1) Gitega\n2) Cyahafi\n77) Komeza', '2': '3) Nyamirambo'});
         state.vars.current_sectors_screen = 1;
         project.getOrCreateDataTable = jest.fn();
-        sectorHandler('*');
+        sectorHandler(77);
         expect(state.vars.current_sectors_screen).toEqual(2);
         expect(sayText).toHaveBeenCalledWith('3) Nyamirambo');
         expect(promptDigits).toHaveBeenCalledWith('select_sector', {'maxDigits': 2, 'submitOnHash': false, 'timeout': 5});
@@ -60,7 +60,7 @@ describe('Sectors handler', () => {
 
     it('should ask a user to retry once their input doesn\'t match any sector', () => {
         state.vars.sectors = JSON.stringify({'1': 'Gitega', '2': 'Cyahafi', '3': 'Nyamirambo'});
-        state.vars.sectors_screens = JSON.stringify({'1': '1) Gitega\n2) Cyahafi\n* Komeza', '2': '3) Nyamirambo'});
+        state.vars.sectors_screens = JSON.stringify({'1': '1) Gitega\n2) Cyahafi\n77) Komeza', '2': '3) Nyamirambo'});
         state.vars.current_sectors_screen = 2;
         project.getOrCreateDataTable = jest.fn();
         sectorHandler('@');

--- a/tester-pack/confirmation/inputHandlers/villageHandler.js
+++ b/tester-pack/confirmation/inputHandlers/villageHandler.js
@@ -50,7 +50,7 @@ module.exports = function villageHandler(input) {
             maxDigits: 2,
             submitOnHash: false
         });
-    } else if(input === '*' && villages_screen[current_villages_screen + 1]) {
+    } else if(input == 77 && villages_screen[current_villages_screen + 1]) {
         state.vars.current_villages_screen = current_villages_screen + 1;
         sayText(villages_screen[state.vars.current_villages_screen]);
         promptDigits('select_village', {

--- a/tester-pack/confirmation/inputHandlers/villageHandler.test.js
+++ b/tester-pack/confirmation/inputHandlers/villageHandler.test.js
@@ -24,7 +24,7 @@ describe('Village handler', () => {
 
     it('should promt the user to select a farmer once the input matches an existinf village', () => {
         state.vars.villages = JSON.stringify({'1': {village: 'Mpazi', village_id: 1}, '2': {village: 'Tetero', village_id: 2}, '3': {village: 'Kinyambo', village_id: 3}});
-        state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n* Komeza', '2': '3) Kinyambo'});
+        state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n77) Komeza', '2': '3) Kinyambo'});
         const table = {queryRows: () => table_cursor};
         project.initDataTableById = () => table;
         villageHandler(1);
@@ -42,7 +42,7 @@ describe('Village handler', () => {
 
     it('should tell the user if there are no registered farmers in the selected village', () => {
         state.vars.villages = JSON.stringify({'1': {village_name: 'Mpazi', village_id: 1}, '2': {village_name: 'Tetero', village_id: 2}, '3': {village_name: 'Kinyambo', village_id: 3}});
-        state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n* Komeza', '2': '3) Kinyambo'});
+        state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n77) Komeza', '2': '3) Kinyambo'});
         table_cursor.results = [];
         const table = {queryRows: () => table_cursor};
         project.initDataTableById = () => table;
@@ -52,20 +52,20 @@ describe('Village handler', () => {
         expect(promptDigits).not.toHaveBeenCalled();
     });
 
-    it('should display a next page when a user inputs *', () => {
+    it('should display a next page when a user inputs 77', () => {
         state.vars.villages = JSON.stringify({'1': {village: 'Mpazi', village_id: 1}, '2': {village: 'Tetero', village_id: 2}, '3': {village: 'Kinyambo', village_id: 3}});
-        state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n* Komeza', '2': '3) Kinyambo'});
+        state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n77) Komeza', '2': '3) Kinyambo'});
         state.vars.current_villages_screen = 1;
         project.initDataTableById = jest.fn();
-        villageHandler('*');
+        villageHandler(77);
         expect(state.vars.current_villages_screen).toEqual(2);
         expect(sayText).toHaveBeenCalledWith('3) Kinyambo');
         expect(promptDigits).toHaveBeenCalledWith('select_village', {'maxDigits': 2, 'submitOnHash': false, 'timeout': 5});
     });
 
-    it('should display a next page when a user inputs *', () => {
+    it('should display a next page when a user inputs 77', () => {
         state.vars.villages = JSON.stringify({'1': {village: 'Mpazi', village_id: 1}, '2': {village: 'Tetero', village_id: 2}, '3': {village: 'Kinyambo', village_id: 3}});
-        state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n* Komeza', '2': '3) Kinyambo'});
+        state.vars.villages_screen = JSON.stringify({'1': '1) Mpazi\n2) Tetero\n77) Komeza', '2': '3) Kinyambo'});
         state.vars.current_villages_screen = 2;
         project.initDataTableById = jest.fn();
         villageHandler('@');

--- a/tester-pack/confirmation/translations/index.js
+++ b/tester-pack/confirmation/translations/index.js
@@ -60,8 +60,8 @@ var translations = {
         'ki': 'Winjijemo imibare ine ya nyuma ya nomera ndangamuntu itari yo. Ongera ugerageze',
     },
     'next_page': {
-        'en': '* Next',
-        'ki': '* Komeza'
+        'en': '77) Next',
+        'ki': '77) Komeza'
     },
 };
 

--- a/tester-pack/status/inputHandlers/nextScreenHandler.test.js
+++ b/tester-pack/status/inputHandlers/nextScreenHandler.test.js
@@ -1,17 +1,17 @@
 const nextScreenHandler = require('./nextScreensHandler');
 
 describe('next page handler', () => {
-    it('should take user on * to a next screen if it is available', () => {
+    it('should take user on 77 to a next screen if it is available', () => {
         state.vars.current_screen = 1;
         state.vars.screens = JSON.stringify({'1': 'page1', '2': 'Registration\n1) Tyrion Lanister\n2) Jon Snow'});
-        nextScreenHandler('*');
+        nextScreenHandler('77');
         expect(sayText).toHaveBeenCalledWith('Registration\n1) Tyrion Lanister\n2) Jon Snow');
     });
 
     it('should prompt user to go to another page if it is available', () => {
         state.vars.current_screen = 1;
         state.vars.screens = JSON.stringify({'1': 'page1', '2': 'Registration\n1) Tyrion Lanister\n2) Jon Snow', '3': '3) The hound'});
-        nextScreenHandler('*');
+        nextScreenHandler('77');
         expect(sayText).toHaveBeenCalledWith('Registration\n1) Tyrion Lanister\n2) Jon Snow');
         expect(promptDigits).toHaveBeenCalledWith('next_farmers_list', {
             maxDigits: 1,

--- a/tester-pack/status/inputHandlers/nextScreensHandler.js
+++ b/tester-pack/status/inputHandlers/nextScreensHandler.js
@@ -2,7 +2,7 @@ module.exports = function nextScreensHandler(input) {
     var screens = JSON.parse(state.vars.screens);
     var current_screen = state.vars.current_screen;
 
-    if(input === '*' && screens[current_screen + 1]) {
+    if(input == 77 && screens[current_screen + 1]) {
         state.vars.current_screen = current_screen + 1;
         sayText(screens[state.vars.current_screen]);
         if(screens[state.vars.current_screen + 1]) {

--- a/tester-pack/status/inputHandlers/registeredConfirmed.test.js
+++ b/tester-pack/status/inputHandlers/registeredConfirmed.test.js
@@ -33,10 +33,10 @@ describe('registered and confirmed', () => {
         '5) Samuel Tally\n' +
         '6) Tyrion Lanister\n' +
         '7) Jon Snow\n' +
-        '* Next');
-        expect(state.vars.screens).toEqual('{"1":"Registration\\n1) Jon Snow\\n2) Samuel Tally\\n3) Tyrion Lanister\\n4) Jon Snow\\n5) Samuel Tally\\n6) Tyrion Lanister\\n7) Jon Snow\\n* Next","2":"8) Samuel Tally\\n9) Tyrion Lanister\\n10) Jon Snow\\n11) Samuel Tally\\n12) Tyrion Lanister\\n"}');
+        '77) Next');
+        expect(state.vars.screens).toEqual('{"1":"Registration\\n1) Jon Snow\\n2) Samuel Tally\\n3) Tyrion Lanister\\n4) Jon Snow\\n5) Samuel Tally\\n6) Tyrion Lanister\\n7) Jon Snow\\n77) Next","2":"8) Samuel Tally\\n9) Tyrion Lanister\\n10) Jon Snow\\n11) Samuel Tally\\n12) Tyrion Lanister\\n"}');
         expect(promptDigits).toHaveBeenCalledWith('next_farmers_list', {
-            maxDigits: 1,
+            maxDigits: 2,
             timeout: 10,
             submitOnHash: false
         });
@@ -69,13 +69,13 @@ describe('registered and confirmed', () => {
         '6) Tyrion Lanister\n' +
         '7) Jon Snow\n' +
         '8) Samuel Tally\n' +
-        '* Next');
+        '77) Next');
         expect(promptDigits).toHaveBeenCalledWith('next_farmers_list', {
-            maxDigits: 1,
+            maxDigits: 2,
             timeout: 10,
             submitOnHash: false
         });
-        expect(state.vars.screens).toEqual('{"1":"Confirmed\\n1) Jon Snow\\n2) Samuel Tally\\n3) Tyrion Lanister\\n4) Jon Snow\\n5) Samuel Tally\\n6) Tyrion Lanister\\n7) Jon Snow\\n8) Samuel Tally\\n* Next","2":"8) Samuel Tally\\n9) Tyrion Lanister\\n10) Jon Snow\\n11) Samuel Tally\\n12) Tyrion Lanister\\n"}');
+        expect(state.vars.screens).toEqual('{"1":"Confirmed\\n1) Jon Snow\\n2) Samuel Tally\\n3) Tyrion Lanister\\n4) Jon Snow\\n5) Samuel Tally\\n6) Tyrion Lanister\\n7) Jon Snow\\n8) Samuel Tally\\n77) Next","2":"8) Samuel Tally\\n9) Tyrion Lanister\\n10) Jon Snow\\n11) Samuel Tally\\n12) Tyrion Lanister\\n"}');
 
     });
 

--- a/tester-pack/status/inputHandlers/registeredConfirmedHandler.js
+++ b/tester-pack/status/inputHandlers/registeredConfirmedHandler.js
@@ -32,7 +32,7 @@ module.exports = function registeredConfirmedHandler(input) {
 
     if(Object.keys(confirmedScreens).length > 1 || Object.keys(registeredScreens).length > 0) {
         promptDigits('next_farmers_list', {
-            maxDigits: 1,
+            maxDigits: 2,
             timeout: 10,
             submitOnHash: false
         });

--- a/tester-pack/translations/index.js
+++ b/tester-pack/translations/index.js
@@ -8,8 +8,8 @@ var translations = {
         'ki': '1) Kwandika\n2)Kwemeza\n3)Aho ngeze'
     },
     'next_page': {
-        'en': '* Next',
-        'ki': '* Komeza'
+        'en': '77) Next',
+        'ki': '77) Komeza'
     },
     'farmers': {
         'en': '$label) $first_name $last_name\n',


### PR DESCRIPTION
Fixing tester pack.
- currently when a user is confirming the reception or checking the status of tester pack, the locations tends to be many hence the list is divided into screens.
- User is given an option to select * to go to another screen. the service works well but due to some reasons suspecting that different phones treats ***** differently, I have changed the option to 77 instead of *.

### testing Tester pack
https://telerivet.com/p/4bee87c0/service/SVa2e7a19f20dc2bc8/edit

**1. confirmation**
*Navigation on telerivet*
- Dial in the shortcode
- From the main menu, choose tester pack as **option 3**
- On the displayed menu, chose confirmation which is available on **option 2**
- On the list of provinces, choose Kigali from **option 2**
- On the list of Districts, choose Nyarugenge available on **option 1**
**(on the sectors screen you can enter 77 to go to the next page)**
- On the list of Sectors, choose Gitega from the next page **option 9**
- On the Cells menu, choose Kora from **option 1**
- On the list of villages choose Mpazi from option **4**
**on the coming farmers men, you can choose 77 to go to the next page**

**2. status**
*Navigation on telerivet*
- Dial in the shortcode
- From the main menu, choose tester pack as **option 3**
- On the displayed menu, chose statuswhich is available on **option 3**
- enter a village id: 11010606
- choose 1 for registered users
- on the list of farmers, you can easily choose 77 to navigate through the screens
