### PR TITLE
Fix screens navigation

### DIFF
--- a/duka-locator/inputHandlers/countyHandler.js
+++ b/duka-locator/inputHandlers/countyHandler.js
@@ -29,7 +29,7 @@ module.exports = function countyHandler(input) {
             maxDigits: 2,
             timeout: 5
         });
-    } else if(input == '*' && state.vars.multiple_countie_screens && state.vars.current_countie_screen + 1 < JSON.parse(state.vars.multiple_countie_screens).length){
+    } else if(input == 77 && state.vars.multiple_countie_screens && state.vars.current_countie_screen + 1 < JSON.parse(state.vars.multiple_countie_screens).length){
         state.vars.current_countie_screen = state.vars.current_countie_screen + 1;
         var countie_screens = JSON.parse(state.vars.multiple_countie_screens);
         var menu = countie_screens[state.vars.current_countie_screen];

--- a/duka-locator/translations/index.js
+++ b/duka-locator/translations/index.js
@@ -55,9 +55,9 @@ var translations = {
         sw: '99) English'
     },
     'next_page': {
-        en: '* Next',
-        'en-ke': '* Next',
-        sw: '* Endelea'
+        en: '77) Next',
+        'en-ke': '77) Next',
+        sw: '77) Endelea'
     }
 };
 

--- a/group-repayments/inputHandlers/groupSummaryHandler.js
+++ b/group-repayments/inputHandlers/groupSummaryHandler.js
@@ -11,7 +11,7 @@ module.exports = function groupSummaryHandler(input) {
     var lang = group_repayment_variables.lang;
     var getMessage = translator(translations, lang);
     var all_screens = JSON.parse(state.vars.all_screens);
-    if(input == '#') {
+    if(input == '44') {
         sayText(all_screens[state.vars.current_screen]);
         promptDigits('view_individual_balance_menu', {
             submitOnHash: false,

--- a/group-repayments/inputHandlers/groupSummaryHandler.test.js
+++ b/group-repayments/inputHandlers/groupSummaryHandler.test.js
@@ -13,7 +13,7 @@ describe('Back to group summary handler', () => {
         global.state.vars.group_repayment_variables = JSON.stringify({lang: 'en'});
         global.state.vars.all_screens = JSON.stringify(['group summary']);
         global.state.vars.current_screen = 0;
-        groupSummaryHandler('#');
+        groupSummaryHandler('44');
         expect(sayText).toHaveBeenCalledWith('group summary');
         expect(promptDigits).toHaveBeenCalledWith('view_individual_balance_menu', {
             submitOnHash: false,
@@ -26,7 +26,7 @@ describe('Back to group summary handler', () => {
         global.state.vars.group_repayment_variables = JSON.stringify({lang: 'en'});
         global.state.vars.all_screens = JSON.stringify(['group summary']);
         global.state.vars.current_screen = 0;
-        groupSummaryHandler('*');
+        groupSummaryHandler('000');
         expect(sayText).toHaveBeenCalledWith('Invalid input, please try again.\ngroup summary');
         expect(promptDigits).toHaveBeenCalledWith('view_individual_balance_menu', {
             submitOnHash: false,
@@ -35,7 +35,7 @@ describe('Back to group summary handler', () => {
         }); 
     });
     it('should call notifyELK',()=>{
-        groupSummaryHandler('*');
+        groupSummaryHandler('000');
         expect(notifyELK).toHaveBeenCalled();
     });
 });

--- a/group-repayments/inputHandlers/individualBalanceHandler.js
+++ b/group-repayments/inputHandlers/individualBalanceHandler.js
@@ -20,7 +20,7 @@ module.exports = function individualBalanceHandler(input) {
     var previous_screen = state.vars.previous_screen;
     var members_last_screen = state.vars.members_last_screen;
     var menu = '';
-    if(input == '*' && next_screen <= members_last_screen) {
+    if(input == '77' && next_screen <= members_last_screen) {
         menu = all_screens[next_screen];
         state.vars.current_screen = next_screen;
         state.vars.next_screen = next_screen + 1;
@@ -31,7 +31,7 @@ module.exports = function individualBalanceHandler(input) {
             maxDigits: 2,
             timeout: 5
         });
-    } else if(input == '#') {
+    } else if(input == '44') {
         if(previous_screen >= 0) {
             menu = all_screens[previous_screen];
             state.vars.current_screen = previous_screen;
@@ -66,7 +66,7 @@ module.exports = function individualBalanceHandler(input) {
                 '$balance': current_member.balance, 
                 '$repaid': current_member.repaid,
                 '$currency': service.vars.currency,
-                '$percentage': current_member['% Repaid'].toFixed(2)}) + getMessage('back', {'$label': '#'}, lang);
+                '$percentage': current_member['% Repaid'].toFixed(2)}) + getMessage('back', {'$label': '44'}, lang);
             sayText(menu);
             promptDigits('back_to_group_summary',{submitOnHash: false, maxDigits: 1, timeout: 5 });
         }

--- a/group-repayments/inputHandlers/individualBalanceHandler.test.js
+++ b/group-repayments/inputHandlers/individualBalanceHandler.test.js
@@ -12,14 +12,14 @@ describe('Back to group summary handler', () => {
         jest.resetModules();
     });
 
-    it('should take the user to the next screen on *', () => {
+    it('should take the user to the next screen on 77', () => {
         global.state.vars.group_repayment_variables = JSON.stringify({lang: 'en', main_menu: 'main menu', main_menu_handler: 'BackToMain'});
         global.state.vars.all_screens = JSON.stringify(['screen1', 'screen2']);
         global.state.vars.current_screen = 0;
         global.state.vars.previous_screen = -1;
         global.state.vars.next_screen = 1;
         global.state.vars.members_last_screen = 1;
-        individualBalanceHandler('*');
+        individualBalanceHandler('77');
         expect(sayText).toHaveBeenCalledWith('screen2');
         expect(state.vars.next_screen).toBe(2);
         expect(state.vars.previous_screen).toBe(0);
@@ -31,14 +31,14 @@ describe('Back to group summary handler', () => {
         });
     });
 
-    it('should take the user to the previous screen on #', () => {
+    it('should take the user to the previous screen on 44', () => {
         global.state.vars.group_repayment_variables = JSON.stringify({lang: 'en', main_menu: 'main menu', main_menu_handler: 'BackToMain'});
         global.state.vars.all_screens = JSON.stringify(['screen1', 'screen2']);
         global.state.vars.current_screen = 1;
         global.state.vars.previous_screen = 0;
         global.state.vars.next_screen = 2;
         global.state.vars.members_last_screen = 1;
-        individualBalanceHandler('#');
+        individualBalanceHandler('44');
         expect(sayText).toHaveBeenCalledWith('screen1');
         expect(state.vars.next_screen).toBe(1);
         expect(state.vars.previous_screen).toBe(-1);
@@ -50,14 +50,14 @@ describe('Back to group summary handler', () => {
         });
     });
 
-    it('should take the user to the previous screen on #', () => {
+    it('should take the user to the previous screen on 44', () => {
         global.state.vars.group_repayment_variables = JSON.stringify({lang: 'en', main_menu: 'main menu', main_menu_handler: 'BackToMain'});
         global.state.vars.all_screens = JSON.stringify(['screen1', 'screen2']);
         global.state.vars.current_screen = 0;
         global.state.vars.previous_screen = -1;
         global.state.vars.next_screen = 1;
         global.state.vars.members_last_screen = 1;
-        individualBalanceHandler('#');
+        individualBalanceHandler('44');
         expect(sayText).toHaveBeenCalledWith('main menu');
         expect(promptDigits).toHaveBeenCalledWith('BackToMain', {
             submitOnHash: false,
@@ -81,7 +81,7 @@ describe('Back to group summary handler', () => {
             'Balance: 60 RwF\n' +
             'Amount repaid: 60 RwF\n' + 
             '% repaid: 50.00%\n' + 
-            '# Go back');
+            '44) Go back');
         expect(promptDigits).toHaveBeenCalledWith('back_to_group_summary', {
             submitOnHash: false,
             maxDigits: 1,

--- a/group-repayments/inputHandlers/lastFourIdDigitsHandler.js
+++ b/group-repayments/inputHandlers/lastFourIdDigitsHandler.js
@@ -50,7 +50,7 @@ module.exports = function lastFourIdDigitsHandler(input) {
     state.vars.group_members = JSON.stringify(group_members);
     var all_screens = [];
     var initialScreen = getMessage('group_credit', {'$groupCredit': group_repayments.credit, '$currency': service.vars.currency}, lang) + getMessage('group_balance', {'$groupBalance': group_repayments.balance, '$currency': service.vars.currency}, lang);
-    var options = getMessage('continue', {'$label': '*'}, lang) + getMessage('back', {'$label': '#'}, lang);
+    var options = getMessage('continue', {'$label': '77'}, lang) + getMessage('back', {'$label': '44'}, lang);
     var index = 0;
     var preFix = index + 1;
     var record = getMessage('group_members_repayments', {'$prefix': preFix,
@@ -74,14 +74,14 @@ module.exports = function lastFourIdDigitsHandler(input) {
     if(preFix < group_members.length) {
         initialScreen = initialScreen + options;
     } else {
-        initialScreen = initialScreen + getMessage('back', {'$label': '#'}, lang);
+        initialScreen = initialScreen + getMessage('back', {'$label': '44'}, lang);
     }
          
     all_screens.push(initialScreen);
     var screen = '';
     for(var i=index; i<group_members.length; ) {
         if(preFix == group_members.length) {
-            options = getMessage('back', {'$label': '#'}, lang);
+            options = getMessage('back', {'$label': '44'}, lang);
         }
         record = getMessage('group_members_repayments', {'$prefix': preFix, 
             '$firstName': group_members[i].firstName, 

--- a/group-repayments/inputHandlers/lastFourIdDigitsHandler.test.js
+++ b/group-repayments/inputHandlers/lastFourIdDigitsHandler.test.js
@@ -22,7 +22,7 @@ describe('Last four nid digits input handler', () => {
         expect(sayText).toHaveBeenCalledWith('Group credit: 12000 RwF\n' +
         'Group balance: 7000 RwF\n' +
         '1) bahati robben: 7000 RwF\n' + 
-        '# Go back');
+        '44) Go back');
         expect(promptDigits).toHaveBeenCalledWith('view_individual_balance_menu', {
             submitOnHash: false,
             maxDigits: 2,

--- a/group-repayments/translations/message-translations.js
+++ b/group-repayments/translations/message-translations.js
@@ -20,9 +20,9 @@ module.exports = {
         'sw': '$label Endelea\n',
     },
     'back': {
-        'en': '$label Go back',
-        'ki': '$label Subira inyuma',
-        'sw': '$label Rudi nyuma'
+        'en': '$label) Go back',
+        'ki': '$label) Subira inyuma',
+        'sw': '$label) Rudi nyuma'
     },
     'group_members_repayments': {
         'en': '$prefix) $firstName $lastName: $balance $currency\n',


### PR DESCRIPTION
the same issue with tester pack.
duka locator and group repayments have * and # as options of navigating the screen. I have changed them to 77 and 44 respectively.

duka locator: https://telerivet.com/p/0c6396c9/service/SV7684c662f118f82e/edit

GROUP leader RW: account number: **28951336**

group repayments RW: https://telerivet.com/p/8799a79f/service/SV215b0cbe269df25d
group repayments: KE: https://telerivet.com/p/0c6396c9/service/SV7684c662f118f82e/edit 


these services should behave exactly as before but with * and # replaced with 77 and 44 respectively