### PR TITLE
Ser 9 184 final

### DIFF
--- a/Roster-endpoints/enrollOrder.js
+++ b/Roster-endpoints/enrollOrder.js
@@ -1,0 +1,33 @@
+
+var Log = require('../logger/elk/elk-logger');
+module.exports = function send_request(requestData) {
+    var response;
+    var enrollmentEndpoint = '/api/USSDEnrollment/Enrollment/';
+    var fullUrl = service.vars.server_name + enrollmentEndpoint;
+    console.log('####FULL-URL: ' + fullUrl);
+    var opts = { headers: {} };
+    opts.headers['Authorization'] = 'Token ' + service.vars.roster_api_key;
+    opts.method = 'POST';
+    opts.data = requestData;
+    console.log('####### requestData:' + requestData);
+    console.log('#### OPtions: ' + JSON.stringify(opts));
+
+    try {
+        response = httpClient.request(fullUrl, opts);
+        if (response.status == 201) {
+            console.log('***************ENR_SUCCESS*******************' + JSON.stringify(response));
+            return true;
+        }else{
+            var logger = new Log();
+            logger.warn('Failed to enroll ',{data: response});
+            console.log('#### ENR_Failed to save' + JSON.stringify(response));
+        }
+    } catch (e) {
+        var log = new Log();
+        log.error('Failed to enroll', {data: e});
+        console.log('Error' + e);
+        return false;
+    }    
+    return false;
+
+};

--- a/Roster-endpoints/enrollOrder.test.js
+++ b/Roster-endpoints/enrollOrder.test.js
@@ -1,0 +1,48 @@
+var enrollOrder = require('./enrollOrder');
+var Log = require('../logger/elk/elk-logger');
+
+jest.mock('../logger/elk/elk-logger');
+
+var mockResponse = {status: 201};
+//const mockRequestData = {'districtId': 1245, 'siteId': 78};
+//var mockUrl = 'http/example.com/api/USSDEnrollment/Enrollment/';
+describe('enroll order test',()=>{
+
+    let mockLogger;
+    beforeEach(()=>{
+        service.vars.server_name = 'http/example.com';
+        mockLogger = {
+            error: jest.fn(),
+            warn: jest.fn()
+        };
+        Log.mockReturnValue(mockLogger);
+    });
+
+    it('should be a function',()=>{
+        expect(enrollOrder).toBeInstanceOf(Function);
+    });
+    it('should return true if the response is 201',()=>{
+        httpClient.request.mockReturnValueOnce(mockResponse);
+        var result = enrollOrder();
+        expect(result).toBeTruthy();
+    });
+    it('should return false if the response is not 201',()=>{
+        httpClient.request.mockReturnValueOnce({status: 409});
+        var result = enrollOrder();
+        expect(result).toBeFalsy();
+    });
+    it('should log a warning  if the response is not 201',()=>{
+        var mockBadResponse = {status: 409};
+        httpClient.request.mockReturnValueOnce(mockBadResponse);
+        enrollOrder();
+        expect(mockLogger.warn).toHaveBeenCalledWith('Failed to enroll ', { data: mockBadResponse});
+    });
+    it('should log the error if an error occurs',()=>{
+        const error = new Error('Failed to enroll');
+        httpClient.request.mockImplementationOnce(()=>{throw error;});
+        enrollOrder();
+        expect(mockLogger.error).toHaveBeenCalledWith('Failed to enroll',{ data: error});
+    });
+
+
+});

--- a/Roster-endpoints/enrollOrder.test.js
+++ b/Roster-endpoints/enrollOrder.test.js
@@ -4,8 +4,7 @@ var Log = require('../logger/elk/elk-logger');
 jest.mock('../logger/elk/elk-logger');
 
 var mockResponse = {status: 201};
-//const mockRequestData = {'districtId': 1245, 'siteId': 78};
-//var mockUrl = 'http/example.com/api/USSDEnrollment/Enrollment/';
+
 describe('enroll order test',()=>{
 
     let mockLogger;

--- a/just-in-time/add-order-handler/addOrderHandler.js
+++ b/just-in-time/add-order-handler/addOrderHandler.js
@@ -1,0 +1,19 @@
+var handlerName = 'add_order_handler';
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+var bundleChoiceHandler = require('../bundle-choice-handler/bundleChoiceHandler');
+module.exports = {
+    handlerName: handlerName,
+    getHandler: function(onFinalizeOrder,displayBundles){
+        return function (input) {
+            notifyELK();
+            if(input == 1){
+                displayBundles(JSON.parse(state.vars.topUpClient).DistrictId);
+                global.promptDigits(bundleChoiceHandler.handlerName);
+            }
+            else if(input == 2){
+                onFinalizeOrder();
+
+            }
+        };
+    }
+};

--- a/just-in-time/add-order-handler/addOrderHandler.test.js
+++ b/just-in-time/add-order-handler/addOrderHandler.test.js
@@ -1,0 +1,35 @@
+const {getHandler} = require ('./addOrderHandler');
+var bundleChoiceHandler = require('../bundle-choice-handler/bundleChoiceHandler');
+var {client}  = require('../../client-enrollment/test-client-data'); 
+
+jest.mock('../../notifications/elk-notification/elkNotification');
+jest.mock('../bundle-choice-handler/bundleChoiceHandler');
+
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+describe('account_number_handler', () => {
+    var addOrderHandler;
+    var onFinalizeOrder, displayBundles;
+
+    beforeAll(()=>{
+        onFinalizeOrder = jest.fn();
+        displayBundles = jest.fn();
+        addOrderHandler = getHandler(onFinalizeOrder, displayBundles);
+        state.vars.topUpClient = JSON.stringify(client);
+
+    });
+
+    it('should call notifyELK ', () => {
+        addOrderHandler(onFinalizeOrder,displayBundles);
+        expect(notifyELK).toHaveBeenCalled();
+    });
+    it('should dispay bundles and prompt for bundle choices with the bundle choice handlerif the uer chooses 1 to add an order ', () =>{
+        addOrderHandler(1);
+        expect(displayBundles).toHaveBeenCalledWith(client.DistrictId);
+        expect(promptDigits).toHaveBeenCalledWith(bundleChoiceHandler.handlerName);
+    });
+    it('should call finalized order if the user chooses 2 to finalize ', () =>{
+        addOrderHandler(2);
+        expect(onFinalizeOrder).toHaveBeenCalled();
+    });
+
+});

--- a/just-in-time/bundle-choice-handler/bundleChoiceHandler.js
+++ b/just-in-time/bundle-choice-handler/bundleChoiceHandler.js
@@ -1,0 +1,41 @@
+var handlerName = 'bundle_choice_handler';
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+
+var bundles,chosenBundle =[];
+
+var isValidBundleInputChoice = function(input){
+    bundles = JSON.parse(state.vars.bundles);
+    chosenBundle = bundles[input-1];
+    if((chosenBundle) &&(chosenBundle.length != 0)){
+        return true;
+    }
+    return false;
+};
+module.exports = {
+    handlerName: handlerName,
+    getHandler: function(onBundleSelected){
+        return function (input) {
+            console.log('inside bundle choice handler'+state.vars.bundles);
+            notifyELK();
+            if (state.vars.multiple_input_menus) {
+                if (input == 44 && state.vars.input_menu_loc > 0) {
+                    state.vars.input_menu_loc = state.vars.input_menu_loc - 1;
+                    var menu = JSON.parse(state.vars.input_menu)[state.vars.input_menu_loc];
+                    global.sayText(menu);
+                    global.promptDigits(handlerName);
+                    return null;
+                }
+                else if (input == 77 && (state.vars.input_menu_loc < state.vars.input_menu_length - 1)) {
+                    state.vars.input_menu_loc = state.vars.input_menu_loc + 1;
+                    menu = JSON.parse(state.vars.input_menu)[state.vars.input_menu_loc];
+                    global.sayText(menu);
+                    global.promptDigits(handlerName);
+                    return null;
+                }
+            }
+            if(isValidBundleInputChoice(input)){
+                onBundleSelected(chosenBundle.bundleId);
+            }
+        };
+    }
+};

--- a/just-in-time/bundle-choice-handler/bundleChoiceHandler.test.js
+++ b/just-in-time/bundle-choice-handler/bundleChoiceHandler.test.js
@@ -1,0 +1,51 @@
+var {handlerName,getHandler} = require('./bundleChoiceHandler');
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+
+jest.fn('../../notifications/elk-notification/elkNotification');
+httpClient.request.mockReturnValue({status: 200});
+describe('order confirmation handler test', ()=>{
+
+    var bundleChoiceHandler;
+    var onBundleSelected;
+    var bundleArray = [{'bundleId': '-3009','bundleInputId': '-12109','bundleName': 'Knapsack Sprayer','price': '2251','inputName': 'Knapsack Sprayer'},{'bundleId': '-2960','bundleInputId': '-11920','bundleName': 'Red Onion','price': '180','inputName': 'Red Creole'}];
+    var inputMenu = [{'bundleId': '-3009','bundleInputId': '-12109','bundleName': 'Knapsack Sprayer','price': '2251','inputName': 'Knapsack Sprayer'},{'bundleId': '-2960','bundleInputId': '-11920','bundleName': 'Red Onion','price': '180','inputName': 'Red Creole'}];
+    beforeAll(()=>{
+        onBundleSelected = jest.fn();
+        bundleChoiceHandler = getHandler(onBundleSelected);
+        state.vars.bundles = JSON.stringify(bundleArray);
+    });
+
+    it('should call ELK',()=>{
+        bundleChoiceHandler();
+        expect(notifyELK).toHaveBeenCalled;
+    });
+    it('should call on bundle selected function if the input from the user correspond to a valid bundle input choice',()=>{
+        state.vars.multiple_input_menus = false;
+        bundleChoiceHandler(1);
+        expect(onBundleSelected).toHaveBeenCalledWith(bundleArray[0].bundleId);
+    });
+    it('should not call on bundle selected function function if the input from the user does  not correspond to a valid bundle',()=>{
+        state.vars.multiple_input_menus = false;
+        bundleChoiceHandler(3);
+        expect(onBundleSelected).not.toHaveBeenCalled();
+    });
+    it('should display the previous menu page if the input is 44 and the previous menu exists',()=>{
+        state.vars.multiple_input_menus = true;
+        state.vars.input_menu_loc = 1;
+        state.vars.input_menu = JSON.stringify(inputMenu);
+        bundleChoiceHandler(44);
+        expect(sayText).toHaveBeenCalledWith(inputMenu[0]);
+        expect(promptDigits).toHaveBeenCalledWith(handlerName);
+    });
+    it('should display the next menu page if the input is 77 and the next menu exists',()=>{
+        state.vars.multiple_input_menus = true;
+        state.vars.input_menu_loc = 0;
+        state.vars.input_menu_length = 3;
+        state.vars.input_menu = JSON.stringify(inputMenu);
+        bundleChoiceHandler(77);
+        expect(sayText).toHaveBeenCalledWith(inputMenu[1]);
+        expect(promptDigits).toHaveBeenCalledWith(handlerName);
+    });
+
+
+});

--- a/just-in-time/justInTime.js
+++ b/just-in-time/justInTime.js
@@ -2,11 +2,24 @@
 var translations = require('./translations');
 var createTranslator = require('../utils/translator/translator');
 var accountNumberHandler = require('./account-number-handler/accountNumberHandler');
+var bundleChoiceHandler = require('./bundle-choice-handler/bundleChoiceHandler');
+var varietyChoiceHandler = require('./variety-choice-handler/varietyChoiceHandler');
+var varietyConfirmationHandler = require('./variety-confirmation-handler/varietyConfirmationHandler');
+var addOrderHandler = require('./add-order-handler/addOrderHandler');
+var orderConfirmationHandler = require('./order-confirmation-handler/orderConfirmationHandler');
 var notifyELK = require('../notifications/elk-notification/elkNotification');
+var enrollOrder = require('../Roster-endpoints/enrollOrder');
 var translate =  createTranslator(translations, project.vars.lang);
+
 module.exports = {
     registerHandlers: function (){
         addInputHandler(accountNumberHandler.handlerName, accountNumberHandler.getHandler(onAccountNumberValidated));
+        addInputHandler(bundleChoiceHandler.handlerName, bundleChoiceHandler.getHandler(onBundleSelected));
+        addInputHandler(varietyChoiceHandler.handlerName, varietyChoiceHandler.getHandler(onVarietyChosen));
+        addInputHandler(varietyConfirmationHandler.handlerName, varietyConfirmationHandler.getHandler(onBundleSelected));
+        addInputHandler(addOrderHandler.handlerName, addOrderHandler.getHandler(onFinalizeOrder,displayBundles));
+        addInputHandler(orderConfirmationHandler.handlerName, orderConfirmationHandler.getHandler(onOrderConfirmed));
+
     },
 
     start: function (account, country,lang) {
@@ -23,6 +36,7 @@ module.exports = {
 function onAccountNumberValidated(){
     var client = JSON.parse(state.vars.topUpClient);
     var remainingLoan = 0;
+    var districtId = client.DistrictId;
     if(client.BalanceHistory.length > 0){
         client.latestBalanceHistory = client.BalanceHistory[0];
         remainingLoan = client.latestBalanceHistory.TotalCredit - client.latestBalanceHistory.TotalRepayment_IncludingOverpayments;
@@ -31,4 +45,216 @@ function onAccountNumberValidated(){
         var amountToPay = remainingLoan-500;
         global.sayText(translate('loan_payment_not_satisfied',{'$amount': amountToPay },state.vars.jitLang));
     }
+    else{
+        displayBundles(districtId);
+        promptDigits(bundleChoiceHandler.handlerName);
+    }
+}
+function onFinalizeOrder(){
+    var orderMessage = '';
+    var allBundles = [];
+    if(state.vars.orders != ' '){
+        allBundles = JSON.parse(state.vars.orders);
+    }
+    for( var j = 0; j < allBundles.length; j++ ){
+        orderMessage = orderMessage + allBundles[j].bundleName + ' ' + allBundles[j].price + '\n';
+    }
+    sayText(translate('final_order_display',{'$orders': orderMessage },state.vars.jitLang));
+    promptDigits(orderConfirmationHandler.handlerName);
+
+}
+
+
+function onVarietyChosen(bundleInput){
+
+    console.log('varieties in onvarietychosen'+ JSON.stringify(bundleInput));
+    state.vars.chosenVariety = JSON.stringify(bundleInput);
+    console.log('varieties in onvarietychosen'+JSON.parse(state.vars.chosenVariety));
+    sayText(translate('variety_confirmation',{'$bundleName': bundleInput.bundleName, '$inputName': bundleInput.inputName},state.vars.jitLang));
+    promptDigits(varietyConfirmationHandler.handlerName);
+}
+
+function onBundleSelected(bundleId, varietychosen, bundleInputId){
+
+
+    var bundleInputs = JSON.parse(state.vars.bundleInputs);
+    var selectedBundle = [];
+    for( var i = 0; i < bundleInputs.length; i++ ){
+        if( bundleInputs[i].bundleId == bundleId){
+            selectedBundle.push(bundleInputs[i]);
+        }
+    }
+    // It means there are more bundleInputs for one bundle(should display the varieties)
+    if(selectedBundle.length > 1 ){
+        // check if the user already selected a variety
+        if(varietychosen){
+            selectedBundle = [];
+            for(i = 0; i < bundleInputs.length; i++ ){
+                if( bundleInputs[i].bundleInputId == bundleInputId){
+                    selectedBundle.push(bundleInputs[i]);
+                }
+            }
+        }
+        else{
+            // Display the varieties(inputs)
+            state.vars.allVarieties = JSON.stringify(selectedBundle);
+            displayVariety(selectedBundle);
+            promptDigits(varietyChoiceHandler.handlerName);
+        }
+    }
+    if(selectedBundle.length == 1){
+        var allBundles = [];
+        if(state.vars.orders != ' '){
+            allBundles = JSON.parse(state.vars.orders);
+        }
+        allBundles.push(selectedBundle[0]);
+        var orderMessage = '';
+        for( var j = 0; j < allBundles.length; j++ ){
+            orderMessage = orderMessage + allBundles[j].bundleName + ' ' + allBundles[j].price + '\n';
+        }
+        //Display confirmation message
+        state.vars.orders = JSON.stringify(allBundles);
+        if(allBundles.length == 2){
+            sayText(translate('final_order_display',{'$orders': orderMessage },state.vars.jitLang));
+            promptDigits(orderConfirmationHandler.handlerName);
+        }
+        else{
+            global.sayText(translate('order_placed', {'$orders': orderMessage}, state.vars.jitLang));
+            global.promptDigits(addOrderHandler.handlerName);
+        }
+    }
+
+}
+
+function onOrderConfirmed(){
+    var client = JSON.parse(state.vars.topUpClient);
+    var bundle = JSON.parse(state.vars.orders);
+    var requestBundles = [];
+    var group_leader_check = require('../shared/rosterApi/checkForGroupLeader');
+    var isGroupLeader = group_leader_check(client.DistrictId, client.ClientId);
+
+    for( var j = 0; j < bundle.length; j++ ){
+        var order = {'bundleId': bundle[j].bundleId, 'bundleQuantity': 1, inputChoices: [parseInt(bundle[j].bundleInputId)] };
+        requestBundles.push(order);
+    }
+    var requestData = {
+        'districtId': client.DistrictId,
+        'siteId': client.SiteId,
+        'groupId': client.GroupId,
+        'accountNumber': client.AccountNumber,
+        'clientId': client.ClientId,
+        'isGroupLeader': isGroupLeader,
+        'clientBundles': requestBundles
+    };
+   
+    if(enrollOrder(requestData)){
+        var message = translate('final_message',{},state.vars.jitLang);
+        sayText(message);
+        project.sendMessage({
+            content: message, 
+            to_number: contact.phone_number
+        });
+    }
+    else{
+        sayText(translate('enrollment_failed',{},state.vars.jitLang));
+    }
+}
+function displayBundles(district){
+    console.log('district ID:' + district);
+    var bundleInputs = getBundlesInputs(district);
+     
+    state.vars.bundleInputs = JSON.stringify(bundleInputs);
+    var unique = [];
+    var bundles = [];
+    var maizeBanedBundleIds= [];
+
+    // Check for maize bundle in the current's client order
+    if(state.vars.orders != ' '){
+        var maizeTable = project.initDataTableById(service.vars.maizeTableId);
+        var currentOrder = JSON.parse(state.vars.orders);
+        var maizeBundleIds = [];
+        var maizeCursor = maizeTable.queryRows();
+
+        while(maizeCursor.hasNext()){
+            var maizeRow = maizeCursor.next(); 
+            maizeBundleIds.push(maizeRow.vars.bundleId);
+        }
+        for (var k = 0; k < currentOrder.length; k++){
+            if(maizeBundleIds.indexOf(currentOrder[k].bundleId) != -1){
+                maizeBanedBundleIds = maizeBundleIds;
+            }
+        }   
+    }
+    if(bundleInputs){
+        //get Unique bundles
+        for( var i = 0; i < bundleInputs.length; i++ ){
+            if( !unique[bundleInputs[i].bundleId]){
+                //check for not allowed bundles
+                if(maizeBanedBundleIds.indexOf(bundleInputs[i].bundleId) == -1){
+                    bundles.push(bundleInputs[i]);
+                }
+                unique[bundleInputs[i].bundleId] = 1;
+            }
+        }
+    }
+    
+    // saved it for easy access in bundleChoiceHandler 
+    state.vars.bundles = JSON.stringify(bundles);
+    
+    // Build the menu for bundles
+    var populateMenu = require('./utils/populate-bundles');
+    var menu = populateMenu(state.vars.jitLang,140,bundles);
+    if (typeof (menu) == 'string') {
+        global.sayText(menu);
+        state.vars.multiple_input_menus = 0;
+        state.vars.input_menu = menu;
+        state.vars.main_menu = menu;
+    }
+    else if (typeof (menu) == 'object') {
+        state.vars.input_menu_loc = 0;
+        state.vars.multiple_input_menus = 1;
+        state.vars.main_menu = menu[state.vars.input_menu_loc];
+        state.vars.input_menu = JSON.stringify(menu);
+        state.vars.input_menu_length = Object.keys(menu).length;
+        global.sayText(menu[state.vars.input_menu_loc]);
+        state.vars.input_menu = JSON.stringify(menu);
+    }
+
+}
+
+function getBundlesInputs(districtId){
+    var table = project.initDataTableById(service.vars.topUpBundleTableId);
+    var bundleInputs = [];
+    var query = {};
+    query['d' + districtId] = 1;
+    query.offered = 1;
+    var cursor = table.queryRows({'vars': query});
+    while(cursor.hasNext()){
+        var row = cursor.next();
+        var currentBundleInput = {bundleId: row.vars.bundleId, bundleInputId: row.vars.bundleInputId, bundleName: row.vars.bundle_name, price: row.vars.price, inputName: row.vars.input_name};
+        bundleInputs.push(currentBundleInput);
+    }
+    return bundleInputs;
+}
+
+function displayVariety(selectedBundle){
+
+    var populateMenu = require('./utils/populate-bundles');
+    var menu = populateMenu(state.vars.jitLang,140,selectedBundle,true);
+    if (typeof (menu) == 'string') {
+        global.sayText(menu);
+        state.vars.multiple_input_menus = 0;
+        state.vars.input_menu = menu;
+        state.vars.main_menu = menu;
+    }
+    else if (typeof (menu) == 'object') {
+        state.vars.input_menu_loc = 0;
+        state.vars.multiple_input_menus = 1;
+        state.vars.main_menu = menu[state.vars.input_menu_loc];
+        state.vars.input_menu = JSON.stringify(menu);
+        state.vars.input_menu_length = Object.keys(menu).length;
+        global.sayText(menu[state.vars.input_menu_loc]);
+        state.vars.input_menu = JSON.stringify(menu);
+    }
+
 }

--- a/just-in-time/justInTime.js
+++ b/just-in-time/justInTime.js
@@ -27,6 +27,7 @@ module.exports = {
         state.vars.account = account;
         state.vars.country = country;
         state.vars.jitLang = lang;
+        state.vars.orders = ' ';
         var translate =  createTranslator(translations, state.vars.jitLang);
         global.sayText(translate('account_number_handler',{},state.vars.jitLang));
         global.promptDigits(accountNumberHandler.handlerName);

--- a/just-in-time/justInTime.test.js
+++ b/just-in-time/justInTime.test.js
@@ -1,16 +1,39 @@
 const accountNumberHandler = require('./account-number-handler/accountNumberHandler');
+const bundleChoiceHandler = require('./bundle-choice-handler/bundleChoiceHandler');
+const addOrderHandler = require('./add-order-handler/addOrderHandler');
+const orderConfirmationHandler = require('./order-confirmation-handler/orderConfirmationHandler');
+const varietyChoiceHandler = require('./variety-choice-handler/varietyChoiceHandler');
+const varietyConfirmationHandler = require('./variety-confirmation-handler/varietyConfirmationHandler');
 const justInTime = require('./justInTime');
 var {client}  = require('../client-enrollment/test-client-data');
 var notifyELK = require('../notifications/elk-notification/elkNotification');
 
 jest.mock('../notifications/elk-notification/elkNotification');
 jest.mock('./account-number-handler/accountNumberHandler');
+jest.mock('./bundle-choice-handler/bundleChoiceHandler');
+jest.mock('./add-order-handler/addOrderHandler');
+jest.mock('./order-confirmation-handler/orderConfirmationHandler');
+jest.mock('./variety-choice-handler/varietyChoiceHandler');
+jest.mock('./variety-confirmation-handler/varietyConfirmationHandler');
 
 const mockAccountNumberHandler = jest.fn();
+const mockBundleChoiceHandler = jest.fn();
+const mockAddOrderHandler = jest.fn();
+const mockOrderConfirmationHandler = jest.fn();
+const mockVarietyChoiceHandler = jest.fn();
+const mockVarietyConfirmationHandler = jest.fn();
 
 const account = 123456789;
 const country = 'KE';
 const jitLang = 'en-ke';
+state.vars.jitLang = 'en-ke';
+state.vars.topUpClient = JSON.stringify(client);
+const phoneNumber = '0786182097';
+var mockRows = [{vars: {'bundleId': '-2009','bundleInputId': '-1709','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input'}},{vars: {'bundleId': '-9009','bundleInputId': '-5709','bundle_name': 'third possible name bundle','price': '6251','input_name': 'third input'}},{vars: {'bundleId': '-1009','bundleInputId': '-8709','bundle_name': 'fourth possible name bundle','price': '5251','input_name': 'fourth input'}},{vars: {'bundleId': '-2009','bundleInputId': '-18909','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input'}}];
+var mockBundleInputs = [{'bundleId': '-2009','bundleInputId': '-1709','bundleName': 'Second possible name bundle','price': '2251','inputName': 'second input'},{'bundleId': '-9009','bundleInputId': '-5709','bundleName': 'third possible name bundle','price': '6251','inputName': 'third input'},{'bundleId': '-1009','bundleInputId': '-8709','bundleName': 'fourth possible name bundle','price': '5251','inputName': 'fourth input'},{'bundleId': '-2009','bundleInputId': '-18909','bundleName': 'Second possible name bundle','price': '2251','inputName': 'second input'}];
+var mockMaizeRows = [{vars: {'bundleId': '-2009','bundleInputId': '-1709','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input'}},{vars: {'bundleId': '-9009','bundleInputId': '-5709','bundle_name': 'third possible name bundle','price': '6251','input_name': 'third input'}}];
+var mockRow = {vars: {'bundleId': '-3009','bundleInputId': '-12109','bundle_name': 'Knapsack Sprayer','price': '2251','input_name': 'Knapsack Sprayer'}};
+var mockBundleInput = [{'bundleId': '-3009','bundleInputId': '-12109','bundleName': 'Knapsack Sprayer','price': '2251','inputName': 'Knapsack Sprayer'}];
 
 describe('clientRegistration', () => {
 
@@ -23,14 +46,48 @@ describe('clientRegistration', () => {
     });
     beforeEach(() => {
         accountNumberHandler.getHandler.mockReturnValue(mockAccountNumberHandler);
+        bundleChoiceHandler.getHandler.mockReturnValue(mockBundleChoiceHandler);
+        addOrderHandler.getHandler.mockReturnValue(mockAddOrderHandler);
+        orderConfirmationHandler.getHandler.mockReturnValue(mockOrderConfirmationHandler);
+        varietyChoiceHandler.getHandler.mockReturnValue(mockVarietyChoiceHandler);
+        varietyConfirmationHandler.getHandler.mockReturnValue(mockVarietyConfirmationHandler);
 
     });
     it('should add the account number handler to input handlers', () => {
         justInTime.registerHandlers();
         expect(addInputHandler).toHaveBeenCalledWith(accountNumberHandler.handlerName, accountNumberHandler.getHandler());            
     });
+    it('should add the bundle Choice Handler  to input handlers', () => {
+        justInTime.registerHandlers();
+        expect(addInputHandler).toHaveBeenCalledWith(bundleChoiceHandler.handlerName, bundleChoiceHandler.getHandler());            
+    });
+    it('should add the add order handler to input handlers', () => {
+        justInTime.registerHandlers();
+        expect(addInputHandler).toHaveBeenCalledWith(addOrderHandler.handlerName, addOrderHandler.getHandler());            
+    });
+    it('should add the order  confirmation handler to input handlers', () => {
+        justInTime.registerHandlers();
+        expect(addInputHandler).toHaveBeenCalledWith(orderConfirmationHandler.handlerName, orderConfirmationHandler.getHandler());            
+    });
+    it('should add the variety choice handler to input handlers', () => {
+        justInTime.registerHandlers();
+        expect(addInputHandler).toHaveBeenCalledWith(varietyChoiceHandler.handlerName, varietyChoiceHandler.getHandler());            
+    });
+    it('should add the variety confirmation handler to input handlers', () => {
+        justInTime.registerHandlers();
+        expect(addInputHandler).toHaveBeenCalledWith(varietyConfirmationHandler.handlerName, varietyConfirmationHandler.getHandler());            
+    });
     describe('Account number handler success callback', () => {
         var callback;
+        const mockCursor = { next: jest.fn(), 
+            hasNext: jest.fn()
+        };
+        const mockTable = { queryRows: jest.fn() };
+        mockTable.queryRows.mockReturnValue(mockCursor);
+        
+        project.initDataTableById.mockReturnValue(mockTable);
+        state.vars.orders =  ' ';
+        state.vars.jitLang ='en-ke';
         beforeEach(() => {
             justInTime.registerHandlers();
             callback = accountNumberHandler.getHandler.mock.calls[0][0];                
@@ -38,6 +95,54 @@ describe('clientRegistration', () => {
         it('should not display a message saying that the prepayment is not one if the prepayment consition is not met',()=>{
             callback();
             expect(sayText).not.toHaveBeenCalledWith(expect.stringContaining('You do not qualify for a top up,'));
+        });
+        it('should display  the bundles if the prepayment condition is satified',()=>{
+            mockCursor.hasNext.mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockRow);
+            callback();
+            expect(sayText).not.toHaveBeenCalledWith(expect.stringContaining('You do not qualify for a top up,'));
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockRow.vars.bundle_name}`+
+            ` ${mockRow.vars.price}`+
+            '\n');
+        });
+        it('should display a the bundles with next and previous options if the prepayment condition is satified and there is a lot of bundles',()=>{
+    
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[1]).mockReturnValueOnce(mockRows[2]);
+            callback();
+            expect(sayText).not.toHaveBeenCalledWith(expect.stringContaining('You do not qualify for a top up,'));
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockRow.vars.bundle_name}`+
+            ` ${mockRow.vars.price}`+
+            `\n2) ${mockRows[0].vars.bundle_name}`+
+            ` ${mockRows[0].vars.price}`+
+            `\n3) ${mockRows[1].vars.bundle_name}`+
+            ` ${mockRows[1].vars.price}`+
+            '\n77)Next page');
+        });
+        it('should display only unique bundles(if two bundle inputs in the same bundle are found) if the prepayment condition is satified ', () => {
+
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[3]);
+            callback();
+            expect(sayText).not.toHaveBeenCalledWith(expect.stringContaining('You do not qualify for a top up,'));
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockRow.vars.bundle_name}`+
+            ` ${mockRow.vars.price}`+
+            `\n2) ${mockRows[0].vars.bundle_name}`+
+            ` ${mockRows[0].vars.price}`+
+            '\n');
+        });
+        it('should remove maize bundles from the displayed bundles if the prepayment condition is satified and the client already choosed a maize bundle',()=>{
+            
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[1]).mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
+            state.vars.orders = JSON.stringify([mockMaizeRows[0]]);
+            callback();
+            expect(sayText).not.toHaveBeenCalledWith(expect.stringContaining('You do not qualify for a top up,'));
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockRow.vars.bundle_name}`+
+            ` ${mockRow.vars.price}`+
+            `\n2) ${mockRows[0].vars.bundle_name}`+
+            ` ${mockRows[0].vars.price}`+
+            '\n');
         });
         it('should display a message saying that the prepayment condition is not satified if the remaining loan is greater than 500', () => {
             client.BalanceHistory[0].TotalCredit = 5000;
@@ -47,6 +152,104 @@ describe('clientRegistration', () => {
             callback();
             expect(sayText).toHaveBeenCalledWith(`You do not qualify for a top up, pay at least ${amount}`+
             ' to qualify.');
+        });
+    });
+    describe('bundle Choice Handler successfull callback',()=>{
+        var callback;
+        beforeEach(() => {
+            justInTime.registerHandlers();
+            callback = bundleChoiceHandler.getHandler.mock.calls[0][0];    
+            state.vars.bundleInputs =  JSON.stringify(mockBundleInputs);      
+        });
+
+        it('should display the varieties for the bundle choosed, if the bundle has multiple varieties',()=>{
+            callback(mockBundleInputs[0].bundleId);
+            expect(sayText).toHaveBeenCalledWith(`Select seed variety\n1) ${mockBundleInputs[0].inputName}`+
+            `\n2) ${mockBundleInputs[3].inputName}`+
+            '\n');
+        });
+        it('should display the order placed by the user and prompt to add order or finalize order',()=>{
+            state.vars.bundleInputs =  JSON.stringify(mockBundleInput);  
+            state.vars.orders = ' ';
+            var orderMessage = mockBundleInput[0].bundleName + ' ' + mockBundleInput[0].price + '\n';
+            callback(mockBundleInput[0].bundleId);
+            expect(sayText).toHaveBeenCalledWith(`Order placed\n ${orderMessage}`+
+            ' \n 1) Add product\n 2) Finish ordering');
+            expect(promptDigits).toHaveBeenCalledWith(addOrderHandler.handlerName);
+        });
+
+    });
+    describe('order Confirmation Handler successfull callback',()=>{
+        var callback;
+        beforeAll(()=>{
+            state.vars.orders = JSON.stringify([mockMaizeRows[0]]);
+        });
+        beforeEach(() => {
+            justInTime.registerHandlers();
+            callback = orderConfirmationHandler.getHandler.mock.calls[0][0];           
+        });
+
+        it('should display a message confirming the order is complete if the order is saved in roster',()=>{
+            httpClient.request.mockReturnValue({status: 201});
+            contact.phone_number = phoneNumber;
+            var message = 'Thank you for placing your Just in Time Top-up order.';
+            callback();
+            expect(sayText).toHaveBeenCalledWith('Thank you for placing your Just in Time Top-up order.');
+            expect(project.sendMessage).toHaveBeenCalledWith({content: message, to_number: phoneNumber});
+        });
+        it('should display a message asking the user to try again later the order is not saved in roster',()=>{
+            httpClient.request.mockReturnValue({status: 500});
+            callback();
+            expect(sayText).toHaveBeenCalledWith('Please try again later. Most people are applying right now!');
+        });
+    });
+
+    describe('variety Choice Handler success callback',()=>{
+        var callback;
+        beforeEach(() => {
+            justInTime.registerHandlers();
+            callback = varietyChoiceHandler.getHandler.mock.calls[0][0]; 
+            state.vars.bundleInputs =  JSON.stringify(mockBundleInputs);           
+        });
+
+        it('should display a confirm variety message and prompt for input',()=>{
+            callback(mockBundleInputs[0]);
+            expect(sayText).toHaveBeenCalledWith(`Top-up with ${mockBundleInputs[0].bundleName}`+
+            ` and ${mockBundleInputs[0].inputName}`+
+            '\n1) Confirm\n2) Cancel');
+            expect(promptDigits).toHaveBeenCalledWith(varietyConfirmationHandler.handlerName);
+        });
+ 
+    });
+    describe('variety Confirmation Handler successfull callback',()=>{
+        var callback;
+        beforeEach(() => {
+            justInTime.registerHandlers();
+            state.vars.orders = ' ';
+            callback = varietyConfirmationHandler.getHandler.mock.calls[0][0];    
+            state.vars.bundleInputs =  JSON.stringify(mockBundleInputs);        
+        });
+        it('should show the order placed',()=>{
+            callback(mockBundleInputs[3].bundleId,true,mockBundleInputs[3].bundleInputId);
+            var orderMessage = mockBundleInputs[3].bundleName + ' ' + mockBundleInputs[3].price + '\n';
+            expect(sayText).toHaveBeenCalledWith(`Order placed\n ${orderMessage}`+
+            ' \n 1) Add product\n 2) Finish ordering');
+
+        });
+
+    });
+    describe('add Order Handler successfull callback',()=>{
+        var callback;
+        beforeEach(() => {
+            justInTime.registerHandlers();
+            state.vars.orders = JSON.stringify(mockBundleInput);
+            callback = addOrderHandler.getHandler.mock.calls[0][0];          
+        });
+        it('should show the order placed',()=>{
+            callback();
+            var orderMessage = mockBundleInput[0].bundleName + ' ' + mockBundleInput[0].price + '\n';
+            expect(sayText).toHaveBeenCalledWith(`Order placed\n ${orderMessage}`+
+            ' \n1) Confirm order');
         });
     });
 

--- a/just-in-time/order-confirmation-handler/orderConfirmationHandler.js
+++ b/just-in-time/order-confirmation-handler/orderConfirmationHandler.js
@@ -1,0 +1,13 @@
+var handlerName = 'order_confirmation_handler';
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+module.exports = {
+    handlerName: handlerName,
+    getHandler: function(onOrderConfirmed){
+        return function (input) {
+            notifyELK();
+            if(input == 1){
+                onOrderConfirmed();
+            }
+        };
+    }
+};

--- a/just-in-time/order-confirmation-handler/orderConfirmationHandler.test.js
+++ b/just-in-time/order-confirmation-handler/orderConfirmationHandler.test.js
@@ -1,0 +1,23 @@
+var {getHandler} = require('./orderConfirmationHandler');
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+
+jest.fn('../../notifications/elk-notification/elkNotification');
+httpClient.request.mockReturnValue({status: 200});
+describe('order confirmation handler test', ()=>{
+
+    var orderConfirmationHandler;
+    var onOrderConfirmed;
+    beforeAll(()=>{
+        onOrderConfirmed = jest.fn();
+        orderConfirmationHandler = getHandler(onOrderConfirmed);
+    });
+
+    it('should call ELK',()=>{
+        orderConfirmationHandler();
+        expect(notifyELK).toHaveBeenCalled;
+    });
+    it('should call on order confirmation function if the user chooses 1',()=>{
+        orderConfirmationHandler();
+        expect(onOrderConfirmed).toHaveBeenCalled;
+    });
+});

--- a/just-in-time/translations.js
+++ b/just-in-time/translations.js
@@ -7,5 +7,40 @@ module.exports = {
     'loan_payment_not_satisfied': {
         'en-ke': 'You do not qualify for a top up, pay at least $amount to qualify.',
         'sw': 'Bado haujahitimu kuongeza bidhaa, lipa $amount  kuhitimu.'
+    },
+    'bundle_title': {
+        'en-ke': 'Select a product',
+        'sw': 'Chagua product'
+    },
+    'variety_title': {
+        'en-ke': 'Select seed variety',
+        'sw': 'Chagua mbegu'
+    },
+    'order_placed': {
+        'en-ke': 'Order placed\n $orders \n 1) Add product\n 2) Finish ordering',
+        'sw': 'Bidhaa ulizo agiza\n $orders \n 1) Ongeza bidhaa\n 2) Maliza ombi'
+    },
+    'final_order_display': {
+        'en-ke': 'Order placed\n $orders \n1) Confirm order',
+        'sw': 'Bidhaa ulizo agiza\n $orders \n1) kudhibitisha'
+    },
+    'final_message': {
+        'en-ke': 'Thank you for placing your Just in Time Top-up order.',
+        'sw': 'Asante kwa kutuma maombi yako ya Just in Time Top-up.'
+    },
+    'variety_confirmation': {
+        'en-ke': 'Top-up with $bundleName and $inputName\n1) Confirm\n2) Cancel',
+        'sw': '"Umeongeza  $bundleName na $inputName\n1) Thibitisha\n 2) Futa"'
+    },'enrollment_failed': {
+        'en-ke': 'Please try again later. Most people are applying right now!',
+        'sw': 'Tafadhali jaribu tena baada ya mda kidogo. Watu wengi wanatuma maombi kwa sasa!'
+
+    },'prev_page': {
+        'en-ke': '44)Previous page',
+        'sw': '44)Previous page'
+    },
+    'next_page': {
+        'en-ke': '77)Next page',
+        'sw': '77)Next page'
     }
 };

--- a/just-in-time/translations.js
+++ b/just-in-time/translations.js
@@ -37,10 +37,10 @@ module.exports = {
 
     },'prev_page': {
         'en-ke': '44)Previous page',
-        'sw': '44)Previous page'
+        'sw': '44)ukurasa uliopita'
     },
     'next_page': {
         'en-ke': '77)Next page',
-        'sw': '77)Next page'
+        'sw': '77)ukurasa unaofuata'
     }
 };

--- a/just-in-time/utils/populate-bundles.js
+++ b/just-in-time/utils/populate-bundles.js
@@ -1,0 +1,65 @@
+var createTranslator = require('../../utils/translator/translator');
+var translations = require('../translations');
+
+module.exports = function(lang, max_chars, content,isVariety){
+
+    
+    console.log('lang is:' +lang);
+    var translate =  createTranslator(translations, lang);
+    var prev_page = translate('prev_page', {}, lang);
+    var next_page = translate('next_page', {}, lang);
+    var title;
+    if(isVariety){
+        title = translate('variety_title', {}, lang); 
+    }
+    else{
+        title = translate('bundle_title', {}, lang);
+    }
+    var optionsLength = content.length;
+    var finalMenu = title + '\n';
+    var currentMenu = '';
+    var loc = 0;
+    var counter = 1;
+    var displayingMenu = {};
+    var sessionMenu = [];
+    for(var i = 0; i < optionsLength ; i++){
+        var currentOption = content[i];
+        if(isVariety){
+            currentMenu = finalMenu + String(counter) + ') ' + currentOption.inputName + '\n';
+        }
+        else{
+            currentMenu = finalMenu + String(counter) +') '+ currentOption.bundleName + ' '+ currentOption.price  + '\n';
+        }
+        if(currentMenu.length < max_chars){
+            if(isVariety){
+                finalMenu = finalMenu + String(counter) + ') ' + currentOption.inputName + '\n';
+            }
+            else{
+                finalMenu = finalMenu + String(counter) + ') ' + currentOption.bundleName + ' '+ currentOption.price  + '\n';
+            }
+        }
+        else{
+            displayingMenu[loc] = finalMenu + next_page;
+            if(isVariety){
+                finalMenu = prev_page + '\n' + String(counter) + ') ' + currentOption.inputName + '\n';
+            }
+            else{
+                finalMenu = prev_page + '\n' + String(counter) + ')' + currentOption.bundleName + ' '+ currentOption.price  + '\n';
+            }
+            loc = loc + 1;
+        }
+        sessionMenu.push(currentOption);
+        counter = counter + 1; 
+    }
+    
+    state.vars.sessionMenu = JSON.stringify(sessionMenu);
+    if(Object.keys(displayingMenu).length > 0){
+        displayingMenu[loc] = displayingMenu[loc] = finalMenu;
+        return displayingMenu;
+    }
+    else{
+        console.log(finalMenu);
+        return finalMenu;
+
+    }
+};

--- a/just-in-time/utils/populate-bundles.test.js
+++ b/just-in-time/utils/populate-bundles.test.js
@@ -1,0 +1,31 @@
+
+var populateBundle = require('./populate-bundles');
+
+var lang  = 'en-ke';
+var maxChars = 140;
+var bundleInputs = [{'bundleId': '-2009','bundleInputId': '-1709','bundleName': 'Second possible name bundle','price': '2251','inputName': 'second input'},{'bundleId': '-9009','bundleInputId': '-5709','bundleName': 'third possible name bundle','price': '6251','inputName': 'third input'},{'bundleId': '-1009','bundleInputId': '-8709','bundleName': 'fourth possible name bundle','price': '5251','inputName': 'fourth input'},{'bundleId': '-2009','bundleInputId': '-18909','bundleName': 'Second possible name bundle','price': '2251','inputName': 'second input'}];
+var fewBundleInputs = [{'bundleId': '-2009','bundleInputId': '-1709','bundleName': 'Second possible name bundle','price': '2251','inputName': 'second input'},{'bundleId': '-9009','bundleInputId': '-5709','bundleName': 'third possible name bundle','price': '6251','inputName': 'third input'}];
+describe('populateBundle test',()=>{
+
+    it('should be a function',()=>{
+        expect(populateBundle).toBeInstanceOf(Function);
+    });
+    it('should populate the menu with the bundles given',()=>{
+        var menu = populateBundle(lang, maxChars,fewBundleInputs);
+        var expectedMenu = 'Select a product\n1) Second possible name bundle 2251\n2) third possible name bundle 6251\n';
+        expect(menu).toEqual(expectedMenu);
+
+    });
+    it('should include next and previous options if the menu is beyond one page',()=>{
+        var menu = populateBundle(lang, maxChars,bundleInputs);
+        var expectedMenu = {'0': 'Select a product\n1) Second possible name bundle 2251\n2) third possible name bundle 6251\n3) fourth possible name bundle 5251\n77)Next page', '1': '44)Previous page\n4)Second possible name bundle 2251\n'};
+        expect(menu).toEqual(expectedMenu);
+    });
+
+    it('should populate the menu with vaieties given',()=>{
+        var menu = populateBundle(lang, maxChars,fewBundleInputs,true);
+        var expectedMenu = 'Select seed variety\n1) second input\n2) third input\n';
+        expect(menu).toEqual(expectedMenu);
+    });
+
+});

--- a/just-in-time/variety-choice-handler/varietyChoiceHandler.js
+++ b/just-in-time/variety-choice-handler/varietyChoiceHandler.js
@@ -1,0 +1,42 @@
+var handlerName = 'variety_choice_handler';
+
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+var chosenInput = [];
+function isValidBundleInput(input, bundleInputs){
+    
+    chosenInput = bundleInputs[input-1];
+    if((chosenInput) && (chosenInput.length != 0)){
+        return true;
+    }
+    return false;
+
+}
+module.exports = {
+    handlerName: handlerName,
+    getHandler: function(onVarietyChosen){
+        return function (input) {
+            var allVarieties = JSON.parse(state.vars.allVarieties);
+            console.log('inside variety choice handler'+JSON.stringify(allVarieties));
+            notifyELK();
+            if (state.vars.multiple_input_menus) {
+                if (input == 44 && state.vars.input_menu_loc > 0) {
+                    state.vars.input_menu_loc = state.vars.input_menu_loc - 1;
+                    var menu = JSON.parse(state.vars.input_menu)[state.vars.input_menu_loc];
+                    global.sayText(menu);
+                    global.promptDigits(handlerName);
+                    return null;
+                }
+                else if (input == 77 && (state.vars.input_menu_loc < state.vars.input_menu_length - 1)) {
+                    state.vars.input_menu_loc = state.vars.input_menu_loc + 1;
+                    menu = JSON.parse(state.vars.input_menu)[state.vars.input_menu_loc];
+                    global.sayText(menu);
+                    global.promptDigits(handlerName);
+                    return null;
+                }
+            }
+            if(isValidBundleInput(input, allVarieties)){
+                onVarietyChosen(chosenInput);
+            }
+        };
+    }
+};

--- a/just-in-time/variety-choice-handler/varietyChoiceHandler.test.js
+++ b/just-in-time/variety-choice-handler/varietyChoiceHandler.test.js
@@ -1,0 +1,51 @@
+var {handlerName,getHandler} = require('./varietyChoiceHandler');
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+
+jest.fn('../../notifications/elk-notification/elkNotification');
+httpClient.request.mockReturnValue({status: 200});
+describe('order confirmation handler test', ()=>{
+
+    var varietyChoiceHandler;
+    var onVarietyChosen;
+    var bundleArray = [{'bundleId': '-3009','bundleInputId': '-12109','bundleName': 'Knapsack Sprayer','price': '2251','inputName': 'Knapsack Sprayer'},{'bundleId': '-2960','bundleInputId': '-11920','bundleName': 'Red Onion','price': '180','inputName': 'Red Creole'}];
+    var inputMenu = [{'bundleId': '-3009','bundleInputId': '-12109','bundleName': 'Knapsack Sprayer','price': '2251','inputName': 'Knapsack Sprayer'},{'bundleId': '-2960','bundleInputId': '-11920','bundleName': 'Red Onion','price': '180','inputName': 'Red Creole'}];
+    beforeAll(()=>{
+        onVarietyChosen = jest.fn();
+        varietyChoiceHandler = getHandler(onVarietyChosen);
+        state.vars.allVarieties = JSON.stringify(bundleArray);
+    });
+
+    it('should call ELK',()=>{
+        varietyChoiceHandler();
+        expect(notifyELK).toHaveBeenCalled;
+    });
+    it('should call on variety choice handler function if the input from the user correspond to a valid bundle',()=>{
+        state.vars.multiple_input_menus = false;
+        varietyChoiceHandler(1);
+        expect(onVarietyChosen).toHaveBeenCalledWith(bundleArray[0]);
+    });
+    it('should not call on variety choice handler function if the input from the user does  not correspond to a valid bundle',()=>{
+        state.vars.multiple_input_menus = false;
+        varietyChoiceHandler(3);
+        expect(onVarietyChosen).not.toHaveBeenCalled();
+    });
+    it('should display the previous menu page if the input is 44 and the previous menu exists',()=>{
+        state.vars.multiple_input_menus = true;
+        state.vars.input_menu_loc = 1;
+        state.vars.input_menu = JSON.stringify(inputMenu);
+        varietyChoiceHandler(44);
+        expect(sayText).toHaveBeenCalledWith(inputMenu[0]);
+        expect(promptDigits).toHaveBeenCalledWith(handlerName);
+    });
+    it('should display the next menu page if the input is 77 and the next menu exists',()=>{
+        state.vars.multiple_input_menus = true;
+        state.vars.input_menu_loc = 0;
+        state.vars.input_menu_length = 3;
+        state.vars.input_menu = JSON.stringify(inputMenu);
+        varietyChoiceHandler(77);
+        expect(sayText).toHaveBeenCalledWith(inputMenu[1]);
+        expect(promptDigits).toHaveBeenCalledWith(handlerName);
+    });
+
+
+});

--- a/just-in-time/variety-confirmation-handler/varietyConfirmationHandler.js
+++ b/just-in-time/variety-confirmation-handler/varietyConfirmationHandler.js
@@ -1,0 +1,14 @@
+var handlerName = 'variety_confirmation_handler';
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+module.exports = {
+    handlerName: handlerName,
+    getHandler: function(onBundleSelected){
+        return function (input) {
+            notifyELK();
+            if(input == 1){
+                var varietyChosen = JSON.parse(state.vars.chosenVariety);
+                onBundleSelected(varietyChosen.bundleId,true,varietyChosen.bundleInputId);
+            }
+        };
+    }
+};

--- a/just-in-time/variety-confirmation-handler/varietyConfirmationHandler.test.js
+++ b/just-in-time/variety-confirmation-handler/varietyConfirmationHandler.test.js
@@ -1,0 +1,24 @@
+var {getHandler} = require('./varietyConfirmationHandler');
+var notifyELK = require('../../notifications/elk-notification/elkNotification');
+
+httpClient.request.mockReturnValue({status: 200});
+jest.fn('../../notifications/elk-notification/elkNotification');
+describe('order confirmation handler test', ()=>{
+
+    var varietyConfirmationHandler;
+    var onBundleSelected;
+    beforeAll(()=>{
+        onBundleSelected = jest.fn();
+        varietyConfirmationHandler = getHandler(onBundleSelected);
+        state.vars.chosenVariety = JSON.stringify([{bundleId: '-2711',bundleInputId: '-11823'}]);
+    });
+
+    it('should call ELK',()=>{
+        varietyConfirmationHandler();
+        expect(notifyELK).toHaveBeenCalled;
+    });
+    it('should call on bundle selected function if the user chooses 1',()=>{
+        varietyConfirmationHandler(1);
+        expect(onBundleSelected).toHaveBeenCalledWith(JSON.parse(state.vars.chosenVariety).bundleId,true, JSON.parse(state.vars.chosenVariety).bundleInputId);
+    });
+});

--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -51,6 +51,15 @@ service.vars.roster_read_key = project.vars.roster_read_key;
 service.vars.lr_2021_client_table_id = project.vars[env+'_lr_2021_client_table_id'];
 var checkGroupLeader = require('../shared/rosterApi/checkForGroupLeader');
 
+if(env == 'prod'){
+    service.vars.topUpBundleTableId = 'DT891c89e9a82b6841';
+    service.vars.maizeTableId = 'DT4c3cd5c415c157d0';
+}
+else{
+    service.vars.topUpBundleTableId = 'DT545a7c5683114b75';
+    service.vars.maizeTableId = 'DT950b2ac0dbb996de';
+}
+
 var MenuCount = 0;
 var MenuNext = false;
 var LocArray="";


### PR DESCRIPTION
Allow group leaders to top up clients' orders.

- Use a group leader account to login: 24450523
- choose option 4: top up on the menu
- enter an account number in the same group(26967747 for someone that meets prepayment conditions)(26967403: someone who doesn't meet prepayment condition)
- choose a bundle to top up(if the bundle has varieties you will then be prompt to choose a variety)
- choose to add products or finalize your order
- you should receive an sms when you finalize your order and the order is saved in Roster

Note that only 2 products can be ordered at the same time, and only one of them should be maize

Test link: https://telerivet.com/p/0c6396c9/service/SVb47209de1fdd2cf0/edit
It can be reviewed through commits: [here](https://github.com/one-acre-fund/ussd-sms/pull/116/commits)


