### PR TITLE
Hotfix ser 230 ser 229

### DIFF
--- a/chicken-services/chicken-eligibility/chickenEligibility.js
+++ b/chicken-services/chicken-eligibility/chickenEligibility.js
@@ -10,7 +10,6 @@ module.exports = function(chicken_table, acc_nber, client_json){
         prepRequired = row.vars.prep_required;
         state.vars.chcken_nber = row.vars.ordered_chickens || 0;
         state.vars.farmer_name  = JSON.parse(state.vars.client_json).FirstName;
-
     }
     else{
         state.vars.client_notfound = true;
@@ -33,6 +32,9 @@ module.exports = function(chicken_table, acc_nber, client_json){
         // else calculate the client's possible maximum
         else{
             state.vars.max_chicken = prepayment_amount / 500;
+        }
+        if(state.vars.max_chicken > state.vars.chcken_nber ){
+            state.vars.max_chicken  = state.vars.chcken_nber;
         }
     }
     //doesn't satify the minimum amount

--- a/chicken-services/chicken-eligibility/chickenEligibility.test.js
+++ b/chicken-services/chicken-eligibility/chickenEligibility.test.js
@@ -55,36 +55,38 @@ describe('chicken_Eligibility', () => {
     });
     it('should define confirmed_chicken variable if the client chicken number is not zero and they have not confirmed', ()=>{
         mockCursor.hasNext.mockReturnValueOnce(true);
-        mockRow ={vars: { ordered_Chickens: 4, confirmed: 0}};
+        mockRow ={vars: { ordered_chickens: 4, confirmed: 0}};
         mockCursor.next.mockReturnValueOnce(mockRow);
         chickenEligibility(mockTable,client.AccountNumber,client);
         expect(state.vars.confirmed_chicken).toBeDefined();
     });
     it('should set state.vars.minimum_amount_paid to true if  prepayment_amount is greater than 1000', ()=>{
-        mockCursor.hasNext.mockReturnValueOnce(false);
+        mockCursor.hasNext.mockReturnValueOnce(true);
         client.BalanceHistory.TotalRepayment_IncludingOverpayments = 10000;
-        client.BalanceHistory.TotalCredit = 2000;
+        mockRow.vars.prep_required = 0;
+        mockCursor.next.mockReturnValueOnce(mockRow);
         chickenEligibility(mockTable,client.AccountNumber,client);
         expect(state.vars.minimum_amount_paid).toBeTruthy();
     });
-    it('should set state.vars.max_chicken to 5 if prepayment_amount is greater than 7500', ()=>{
-        mockCursor.hasNext.mockReturnValueOnce(false);
+    it('should set state.vars.max_chicken to 4 if prepayment_amount is greater than 7500 but the client ordered less than the maximum number of chickens that can be ordered', ()=>{
+        mockCursor.hasNext.mockReturnValueOnce(true);
+        var new_row ={vars: { ordered_chickens: 4, confirmed: 0,prep_required: 2000}};
         client.BalanceHistory.TotalRepayment_IncludingOverpayments = 10000;
-        client.BalanceHistory.TotalCredit = 2000;
+        mockCursor.next.mockReturnValueOnce(new_row);
         chickenEligibility(mockTable,client.AccountNumber,client);
-        expect(state.vars.max_chicken).toBe(5);
+        expect(state.vars.max_chicken).toBe(4);
     });
     it('should set state.vars.max_chicken to the number of possible chicken given the prepayment_amount (if the prepayment is greater than 1000 and allows less than 5 possible chicken)', ()=>{
         mockCursor.hasNext.mockReturnValueOnce(true);
-        mockRow ={vars: { ordered_Chickens: 4, confirmed: 0,prep_required: 2000}};
+        var new_row ={vars: { ordered_chickens: 4, confirmed: 0,prep_required: 2000}};
         client.BalanceHistory.TotalRepayment_IncludingOverpayments = 4000;
-        mockCursor.next.mockReturnValueOnce(mockRow);
+        mockCursor.next.mockReturnValueOnce(new_row);
         chickenEligibility(mockTable,client.AccountNumber,client);
         expect(state.vars.max_chicken).toBe(4);
     });
     it('should set state.vars.minimum_amount_paid to False if prepayment_amount is less than 1000', ()=>{
         mockCursor.hasNext.mockReturnValueOnce(true);
-        mockRow ={vars: { ordered_Chickens: 4, confirmed: 0,prep_required: 2000}};
+        mockRow ={vars: { ordered_chickens: 4, confirmed: 0,prep_required: 2000}};
         client.BalanceHistory.TotalRepayment_IncludingOverpayments = 2500;
         mockCursor.next.mockReturnValueOnce(mockRow);
         chickenEligibility(mockTable,client.AccountNumber,client);

--- a/client-registration/clientRegistration.js
+++ b/client-registration/clientRegistration.js
@@ -139,6 +139,8 @@ function saveClientInRoster(){
                     'last_name': clientData.LastName,
                     'district': clientData.DistrictId,
                     'site': clientData.SiteId,
+                    'district_name': client.DistrictName,
+                    'site_name': client.SiteName,
                     'new_client': '1',
                     'gl_interested': groupLeaderInterested,
                     'gl_phone_number': contact.phone_number,

--- a/client-registration/clientRegistration.test.js
+++ b/client-registration/clientRegistration.test.js
@@ -331,6 +331,8 @@ describe('clientRegistration', () => {
                     'last_name': client.LastName,
                     'district': client.DistrictId,
                     'site': client.SiteId,
+                    'district_name': client.DistrictName,
+                    'site_name': client.SiteName,
                     'new_client': '1',
                     'gl_phone_number': contact.phone_number,
                     'gl_interested': state.vars.groupLeader
@@ -351,6 +353,8 @@ describe('clientRegistration', () => {
                     'last_name': client.LastName,
                     'district': client.DistrictId,
                     'site': client.SiteId,
+                    'district_name': client.DistrictName,
+                    'site_name': client.SiteName,
                     'new_client': '1',
                     'gl_phone_number': contact.phone_number,
                     'gl_interested': '0'

--- a/rw-legacy/extension-survey.js
+++ b/rw-legacy/extension-survey.js
@@ -64,11 +64,10 @@ var extensionTable =  project.initDataTableById(service.vars.extensionTableId);
 
 // display welcome message and prompt user to choose their survey (AMA1, AMA2, GUS)
 global.main = function(){
-    sayText(msgs('ext_main_splash'));
     var menu = populate_menu(extension_main_menu_table, lang);
     if (typeof (menu) == 'string') {
         state.vars.current_menu_str = menu;
-        sayText(menu);
+        sayText(msgs('ext_main_splash')+menu);
         state.vars.multiple_input_menus = 0;
         state.vars.input_menu = menu;
         promptDigits('ext_main_splash', { 'submitOnHash': false, 'maxDigits': max_digits_for_input, 'timeout': timeout_length });
@@ -78,7 +77,7 @@ global.main = function(){
         state.vars.multiple_input_menus = 1;
         state.vars.input_menu_length = Object.keys(menu).length; //this will be 1 greater than max possible loc
         state.vars.current_menu_str = menu[state.vars.input_menu_loc];
-        sayText(menu[state.vars.input_menu_loc]);
+        sayText(msgs('ext_main_splash')+menu[state.vars.input_menu_loc]);
         state.vars.input_menu = JSON.stringify(menu);
         promptDigits('ext_main_splash', { 'submitOnHash': false, 'maxDigits': max_digits_for_input, 'timeout': timeout_length });
     }


### PR DESCRIPTION
**SER-231** Update the data collection to store district and site names instead of IDs

Follow the client registration steps:
- Enter a GL account number: 24450523
- Choose option 3 register client(there are two now because when the second one go live we will remove the first one)
- Choose 0 to register a new client
- Enter any 8 digit number as national ID 
- Enter any names(first and last)
- Enter a phone number: 0712301351
- choose any option for GL interest
**It should now save the district name and the site name in the registration table** [here](https://telerivet.com/p/0c6396c9/data/dev_5Flr_5F2021_5Fclient_5Ftable)

Test service link: https://telerivet.com/p/0c6396c9/service/SVb47209de1fdd2cf0/edit

**SER-232** Ensure that chicken prepayment and monthly cap logic is working correctly

- Enter account number: 23560396
- choose option 5: confirm chicken
- It should display as max what the client ordered(3) instead of 5 (given that he paid the required prepayment)

Test service link: https://telerivet.com/p/8799a79f/service/SV1161debc042a9de0/edit

**SER-229** : Update tester pack menu option name and make it the first option in the menu
When you dial, the new lines should be removed and the tester pack(imbuto zigeregeza) should be the first option
Test link: https://telerivet.com/p/4bee87c0/service/SVedf077410a106724/edit