### PR TITLE
Ser 233 234 add ward name digit chicken number

### DIFF
--- a/chicken-services/possible-order-handler/possibleOrderHandler.js
+++ b/chicken-services/possible-order-handler/possibleOrderHandler.js
@@ -8,7 +8,7 @@ module.exports = {
     getHandler: function(onOrderingConfirmed){
         notifyELK();
         return function(input){
-            if((input >= 2) && (input <= state.vars.max_chicken)){
+            if(((input - Math.floor(input)) == 0) && (input >= 2) && (input <= state.vars.max_chicken)){
                 state.vars.confirmed_number = input;
                 onOrderingConfirmed();
             }

--- a/chicken-services/possible-order-handler/possibleOrderHandler.test.js
+++ b/chicken-services/possible-order-handler/possibleOrderHandler.test.js
@@ -39,5 +39,10 @@ describe('possible_order_handler', () => {
         possibleOrderHandler('12');
         expect(promptDigits).toHaveBeenCalledWith(handlerName);
     });
+    it('should show prompt for re-entry if unexpected input(containing decimals)', () => {
+        project.vars.lang = 'en';
+        possibleOrderHandler('3.5');
+        expect(promptDigits).toHaveBeenCalledWith(handlerName);
+    });
 });
 

--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -2022,6 +2022,7 @@ addInputHandler('FOLocWard', function(Ward) {
             if (WardArray[j].Menu == Ward) {
                 LocValid = true;
                 LocID = WardArray[j].ID;
+                state.vars.FOLocatorWardName = WardArray[j].Name;
             }
         }
         if (LocValid || Ward.toLowerCase() == 'a'|| Ward =='*'){
@@ -2141,6 +2142,7 @@ addInputHandler('FOLocConfrim', function(Confirm) {
             vars: {
                 ProspectPN: contact.phone_number,
                 SiteName: state.vars.FOLocatorSiteName,
+                WardName: state.vars.FOLocatorWardName,
                 FOName: state.vars.FOName,
                 FOPhoneNumber: state.vars.FOPN 
             }


### PR DESCRIPTION
SER- 233: **Prevent chicken clients from ordering partial chickens**
- Added a check to see if the user entered a whole number. prompt them to retry if not

SER-234: **Add ward name to FO_Locator_Prospects data table**
- Saving ward name in the dataTable of FO_Locator prospect
Steps to test:
- Enter 0 instead of an account number
- Choose 1 on the next menu for Locate FO
- Choose 1 for the next menus until reached to the ward selection
- Choose 1 for ward(Riakanau in this case) then 1 for site (Riakanau  in this case)
- Choose 1 to approve FO to reach out to you
 A row should be saved in this table [FOProspectTable](https://telerivet.com/p/0c6396c9/data/FO_5FLocator_5FProspects) with the ward name included

-Test link: https://telerivet.com/p/0c6396c9/service/SVb47209de1fdd2cf0/edit