### PR TITLE
update FOLocator message and add national Id step

### DIFF
--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -1362,6 +1362,10 @@ var JITENationalInvalidText = function(){
     if (GetLang()){sayText('Invalid entry.\nPlease enter a valid national id.');}
     else {sayText('Usajili usiosahihi\nTafadhali weka nambari sahihi ya kitambulisho');}
 };
+var NationalInvalidText = function(){
+    if (GetLang()){sayText('Invalid entry.\nPlease enter a valid national id.');}
+    else {sayText('Usajili usiosahihi\nTafadhali weka nambari sahihi ya kitambulisho');}
+};
 var JITEAlreadyOrderedText = function(){
     if (GetLang()){sayText('This person already placed an order.\n1) Back to menu');}
     else {sayText('Mtu huyu tayari ameweka agizo/ ameitisha bidhaa\n1) Rudi kwa menu');}
@@ -1390,8 +1394,16 @@ var JITEOrdeCloseText = function(){
 };
 // FO Locator
 var FOLocatorRegionText = function (){
-    if (GetLang()){sayText('To find your Field Officer Select region\n1) Central\n2) Nyanza\n3) Rift Valley\n4) Western\n#) My region is not listed');}
-    else {sayText('Kupata afisa wa nyanjani, chagua Mkoa wako\n1) Central\n2) Nyanza\n3) Rift Valley\n4) Western\n#) Mkoa wangu hauko kwenye orodha');}
+    if (GetLang()){sayText('To learn more we will connect you with a staff near you. Select Province\n1) Central\n2) Nyanza\n3) Rift Valley\n4) Western\n#)  My province is not in the list');}
+    else {sayText('Kwa maelezo zaidi tutakuelekeza na mfanya kazi aliye karibu nawe. Chagua wilaya.\n1) Central\n2) Nyanza\n3) Rift Valley\n4) Western\n#)  Wilaya yangu haipo hapa');}
+};
+var EnterNationalIdText = function(){
+    if (GetLang()){sayText('What is your national ID?');}
+    else {sayText('Weka nambari ya kitambulisho ya mkulima?');}
+};
+var ConfirmNationalIdText = function(id){
+    if (GetLang()){sayText('You enter'+ id +' ID. Enter\n1) To confirm or \n2) To try again.');}
+    else {sayText('Umeweka nambari ya kitambulisho'+ id +'. Weka\n1) kudhibitisha au \n2) kujaribu tena.');}
 };
 var LocationNotKnownText = function(){
     if (GetLang()){sayText('Sorry OAF does not work in your area');}
@@ -1624,8 +1636,8 @@ addInputHandler('NonClientMenu', function(input) {
         promptDigits('NonClientMenu', {submitOnHash: true, maxDigits: 2, timeout: 5});
     }
     else if(sessionMenu[input-1].option_name == 'find_oaf_contact'){
-        FOLocatorRegionText();
-        promptDigits('FOLocRegion', {submitOnHash: true, maxDigits: 1, timeout: 5});
+        EnterNationalIdText();
+        promptDigits('FONationaIdHandler', {submitOnHash: true, maxDigits: 1, timeout: 5});
     }
     else if(sessionMenu[input-1].option_name == 'trainings'){
         TrainingMenuText();
@@ -1837,6 +1849,35 @@ addInputHandler('PaymentAmount', function(PaymentAmount) {
     else{
         PaymentRetryText();
         promptDigits('PaymentAmount', {submitOnHash: true, maxDigits: 5, timeout: 5});
+    }
+});
+addInputHandler('FONationaIdHandler', function( nationaId){
+    LogSessionID();
+    InteractionCounter('FONationaIdHandler');
+    if(ValNationalID(nationaId)){
+        state.vars.nationalId = nationaId;
+        ConfirmNationalIdText(nationaId);
+        promptDigits('confirmNationalIdHanlder', {submitOnHash: true, maxDigits: 5, timeout: 5});
+    }else{
+        NationalInvalidText();
+        promptDigits('FONationaIdHandler', {submitOnHash: true, maxDigits: 5, timeout: 5});
+    }
+
+});
+addInputHandler('confirmNationalIdHanlder', function(input){
+    LogSessionID();
+    InteractionCounter('confirmNationalIdHanlder');
+    if(input == 1){
+        FOLocatorRegionText();
+        promptDigits('FOLocRegion', {submitOnHash: true, maxDigits: 1, timeout: 5});
+    }
+    else if (input == 2 ){
+        EnterNationalIdText();
+        promptDigits('FONationaIdHandler', {submitOnHash: true, maxDigits: 1, timeout: 5});
+    }
+    else{
+        ConfirmNationalIdText(state.vars.nationalId);
+        promptDigits('confirmNationalIdHanlder', {submitOnHash: true, maxDigits: 5, timeout: 5});
     }
 });
 addInputHandler('FOLocRegion', function(Region) {
@@ -2144,7 +2185,8 @@ addInputHandler('FOLocConfrim', function(Confirm) {
                 SiteName: state.vars.FOLocatorSiteName,
                 WardName: state.vars.FOLocatorWardName,
                 FOName: state.vars.FOName,
-                FOPhoneNumber: state.vars.FOPN 
+                FOPhoneNumber: state.vars.FOPN,
+                NationalId: state.vars.nationalId
             }
         });
         ProspectRow.save();

--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -1402,8 +1402,8 @@ var EnterNationalIdText = function(){
     else {sayText('Weka nambari ya kitambulisho ya mkulima?');}
 };
 var ConfirmNationalIdText = function(id){
-    if (GetLang()){sayText('You enter'+ id +' ID. Enter\n1) To confirm or \n2) To try again.');}
-    else {sayText('Umeweka nambari ya kitambulisho'+ id +'. Weka\n1) kudhibitisha au \n2) kujaribu tena.');}
+    if (GetLang()){sayText('You enter '+ id +' ID. Enter\n1) To confirm or \n2) To try again.');}
+    else {sayText('Umeweka nambari ya kitambulisho '+ id +'. Weka\n1) kudhibitisha au \n2) kujaribu tena.');}
 };
 var LocationNotKnownText = function(){
     if (GetLang()){sayText('Sorry OAF does not work in your area');}

--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -1637,7 +1637,7 @@ addInputHandler('NonClientMenu', function(input) {
     }
     else if(sessionMenu[input-1].option_name == 'find_oaf_contact'){
         EnterNationalIdText();
-        promptDigits('FONationaIdHandler', {submitOnHash: true, maxDigits: 1, timeout: 5});
+        promptDigits('FONationaIdHandler', {submitOnHash: true, maxDigits: 8, timeout: 5});
     }
     else if(sessionMenu[input-1].option_name == 'trainings'){
         TrainingMenuText();
@@ -1857,10 +1857,10 @@ addInputHandler('FONationaIdHandler', function( nationaId){
     if(ValNationalID(nationaId)){
         state.vars.nationalId = nationaId;
         ConfirmNationalIdText(nationaId);
-        promptDigits('confirmNationalIdHanlder', {submitOnHash: true, maxDigits: 5, timeout: 5});
+        promptDigits('confirmNationalIdHanlder', {submitOnHash: true, maxDigits: 8, timeout: 5});
     }else{
         NationalInvalidText();
-        promptDigits('FONationaIdHandler', {submitOnHash: true, maxDigits: 5, timeout: 5});
+        promptDigits('FONationaIdHandler', {submitOnHash: true, maxDigits: 8, timeout: 5});
     }
 
 });
@@ -1869,11 +1869,11 @@ addInputHandler('confirmNationalIdHanlder', function(input){
     InteractionCounter('confirmNationalIdHanlder');
     if(input == 1){
         FOLocatorRegionText();
-        promptDigits('FOLocRegion', {submitOnHash: true, maxDigits: 1, timeout: 5});
+        promptDigits('FOLocRegion', {submitOnHash: true, maxDigits: 8, timeout: 5});
     }
     else if (input == 2 ){
         EnterNationalIdText();
-        promptDigits('FONationaIdHandler', {submitOnHash: true, maxDigits: 1, timeout: 5});
+        promptDigits('FONationaIdHandler', {submitOnHash: true, maxDigits: 8, timeout: 5});
     }
     else{
         ConfirmNationalIdText(state.vars.nationalId);

--- a/ke-legacy/utils/menus/populate-menu/nonClientMainMenu.js
+++ b/ke-legacy/utils/menus/populate-menu/nonClientMainMenu.js
@@ -1,21 +1,21 @@
 module.exports = [
     {
-        'en-ke': 'Find my One Acre Fund contact',
-        'sw': 'Pata Afisa wa Nyanjani wa One Acre Fund',
+        'en-ke': 'Join One Acre Fund',
+        'sw': 'Jiunge na One Acre Fund',
         'option_name': 'find_oaf_contact',
         'end_date': project.vars.end_find_oaf_contact,
         'start_date': project.vars.start_find_oaf_contact
     },
     {
-        'en-ke': 'Trainings',
-        'sw': 'Mafunzo',
+        'en-ke': 'Find Training',
+        'sw': 'Pata Mafunzo',
         'option_name': 'trainings',
         'end_date': project.vars.end_training_non_client,
         'start_date': project.vars.start_training_non_client
     },
     {
-        'en-ke': 'Locate an OAF duka',
-        'sw': 'Lipate duka la OAF',
+        'en-ke': 'Find OAF Duka',
+        'sw': 'Pata Duka la OAF',
         'option_name': 'locate_oaf_duka',
         'end_date': project.vars.end_locate_duka,
         'start_date': project.vars.start_locate_duka

--- a/ke-legacy/utils/menus/populate-menu/test.js
+++ b/ke-legacy/utils/menus/populate-menu/test.js
@@ -56,7 +56,7 @@ describe('ChickenServices', () => {
         const menu = populateMenu(lang,140,false);
         console.log(menu);
         expect(typeof menu).toEqual('string');
-        expect(menu).toMatch('1) Find my One Acre Fund contact\n2) Trainings\n3) Locate an OAF duka');
+        expect(menu).toMatch('1) Join One Acre Fund\n2) Find Training\n3) Find OAF Duka');
 
     });
     it('should not return an option that doesn\'t satisfy the date condition',()=>{
@@ -66,7 +66,7 @@ describe('ChickenServices', () => {
         const menu = populateMenu(lang,140,false);
         console.log(menu);
         expect(typeof menu).toEqual('string');
-        expect(menu).toMatch('1) Trainings\n2) Locate an OAF duka');
+        expect(menu).toMatch('1) Find Training\n2) Find OAF Duka');
 
     });
     it('should return an object of all the options if the character is greater than 140 satisfy the date condition',()=>{        


### PR DESCRIPTION
updated the message on the main non-client menu as well as the select location menu.
Added a step for prompting the national ID then save it to the Prospects clients dataTable
- Choose 0 to access a non-client menu
- Choose 1 to find Fo
- Enter a national ID
- Confirm
- Go to any location
- At the end it will save the info including the national ID [here](https://telerivet.com/p/0c6396c9/data/FO_5FLocator_5FProspects)
Test link: https://telerivet.com/p/0c6396c9/service/SV52afe381873857ad/edit