### PR TITLE
HOTFIX- SER-237-added a check for already stored national id in the prospective clien…

### DIFF
--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -1868,8 +1868,25 @@ addInputHandler('confirmNationalIdHanlder', function(input){
     LogSessionID();
     InteractionCounter('confirmNationalIdHanlder');
     if(input == 1){
-        FOLocatorRegionText();
-        promptDigits('FOLocRegion', {submitOnHash: true, maxDigits: 8, timeout: 5});
+        var ProspectTable = project.getOrCreateDataTable('FO_Locator_Prospects');
+        var cursor = ProspectTable.queryRows({ 'vars': {'NationalId': state.vars.nationalId }});
+        if(cursor.hasNext()){
+            var row = cursor.next();
+            state.vars.FOName = row.vars.FOName;
+            state.vars.FOPN = row.vars.FOPhoneNumber;
+            var FarmerSMSContent = FOLocatorFarmerSMS();
+            project.scheduleMessage({
+                message_type: 'service', 
+                to_number: contact.phone_number, 
+                start_time_offset: 0,
+                service_id: 'SVc758c8b7ad90dd27',
+                vars: {content: FarmerSMSContent}
+            });
+        }
+        else{
+            FOLocatorRegionText();
+            promptDigits('FOLocRegion', {submitOnHash: true, maxDigits: 8, timeout: 5});
+        }
     }
     else if (input == 2 ){
         EnterNationalIdText();


### PR DESCRIPTION
…ts table
SER-237: Prevent prospective clients from using the FO locator service multiple times

Added a check for national Id in the prospective clients:

To test:
- choose 0 from the main menu
- choose 1 to find FO locator
- Enter for national ID : **14523678**
- choose 1 to confirm Id
**It should send a message with the FO contact instead of continuing with the location steps**

test link: https://telerivet.com/p/0c6396c9/service/SV52afe381873857ad/edit
