### PR TITLE
added sending an sms to the client stored phone number in just in time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 
 ## *Unreleased*
 
+
+
+## 2020-09-23
+## Added
+
+* [SER-209](https://oneacrefund.atlassian.net/browse/SER-209) As a client, I want to add avocado trees to my order, so that I can plant a high-impact product
+
+## Changed
+
+* [SER-9](https://oneacrefund.atlassian.net/browse/SER-9)As a GL, I want to be able to top up a client's order via USSD, so that I can adjust orders prior to distribution
+
+
 ## 2020-09-21
 ### Added
 

--- a/just-in-time/justInTime.js
+++ b/just-in-time/justInTime.js
@@ -10,6 +10,7 @@ var orderConfirmationHandler = require('./order-confirmation-handler/orderConfir
 var notifyELK = require('../notifications/elk-notification/elkNotification');
 var enrollOrder = require('../Roster-endpoints/enrollOrder');
 var translate =  createTranslator(translations, project.vars.lang);
+var getPhoneNumber = require('../shared/rosterApi/getPhoneNumber');
 
 module.exports = {
     registerHandlers: function (){
@@ -155,6 +156,16 @@ function onOrderConfirmed(){
             content: message, 
             to_number: contact.phone_number
         });
+        var phone_numbers = getPhoneNumber(client.AccountNumber, client.CountryName);
+        if(phone_numbers) {
+            var active_phone_numbers = phone_numbers.filter(function(phone_number) {
+                return !phone_number.IsInactive;
+            });
+            project.sendMessage({
+                content: message,
+                to_number: active_phone_numbers[0].PhoneNumber,
+            });
+        }
     }
     else{
         sayText(translate('enrollment_failed',{},state.vars.jitLang));

--- a/just-in-time/justInTime.js
+++ b/just-in-time/justInTime.js
@@ -148,9 +148,14 @@ function onOrderConfirmed(){
         'isGroupLeader': isGroupLeader,
         'clientBundles': requestBundles
     };
-   
+    var orderPlacedMessage = '';
     if(enrollOrder(requestData)){
-        var message = translate('final_message',{},state.vars.jitLang);
+        var orderPlaced = JSON.parse(state.vars.orders);
+        console.log(orderPlaced);
+        for( var m = 0; m < orderPlaced.length; m++ ){
+            orderPlacedMessage = orderPlacedMessage + orderPlaced[m].bundleName + ' ' + orderPlaced[m].price + ' ';
+        } 
+        var message = translate('final_message',{'$products': orderPlacedMessage},state.vars.jitLang);
         sayText(message);
         project.sendMessage({
             content: message, 

--- a/just-in-time/justInTime.test.js
+++ b/just-in-time/justInTime.test.js
@@ -183,8 +183,10 @@ describe('clientRegistration', () => {
     });
     describe('order Confirmation Handler successfull callback',()=>{
         var callback;
+        var orders = [{'bundleName': 'Maize','price': 1000},{'bundleName': 'Pesticide','price': 3000}];
+        var ordersMessage = orders[0].bundleName + ' ' + orders[0].price + ' '+orders[1].bundleName + ' ' + orders[1].price+' ';
         beforeAll(()=>{
-            state.vars.orders = JSON.stringify([mockMaizeRows[0]]);
+            state.vars.orders = JSON.stringify(orders);
         });
         beforeEach(() => {
             justInTime.registerHandlers();
@@ -194,18 +196,20 @@ describe('clientRegistration', () => {
         it('should send a message confirming the order is complete if the order is saved in roster',()=>{
             httpClient.request.mockReturnValue({status: 201});
             contact.phone_number = phoneNumber;
-            var message = 'Thank you for placing your Just in Time Top-up order.';
+            var message = `Thanks for ordering ${ordersMessage}`+
+            '. Thank you for topping-up through JiT.';
             callback();
-            expect(sayText).toHaveBeenCalledWith('Thank you for placing your Just in Time Top-up order.');
+            expect(sayText).toHaveBeenCalledWith(message);
             expect(project.sendMessage).toHaveBeenCalledWith({content: message, to_number: phoneNumber});
         });
         it('should send a message to the stored client\'s phone confirming the order is complete if the order is saved in roster',()=>{
             var inactive_number = {'PhoneNumber': '0786182098', 'IsInactive': false};
             var active_number ={'PhoneNumber': '0786182098', 'IsInactive': true};
             getPhoneNumber.mockReturnValue([inactive_number, active_number]);
-            var message = 'Thank you for placing your Just in Time Top-up order.';
+            var message = `Thanks for ordering ${ordersMessage}`+
+            '. Thank you for topping-up through JiT.';
             callback();
-            expect(sayText).toHaveBeenCalledWith('Thank you for placing your Just in Time Top-up order.');
+            expect(sayText).toHaveBeenCalledWith(message);
             expect(project.sendMessage).toHaveBeenCalledWith({content: message, to_number: active_number.PhoneNumber});
         });
         it('should display a message asking the user to try again later the order is not saved in roster',()=>{

--- a/just-in-time/translations.js
+++ b/just-in-time/translations.js
@@ -25,8 +25,8 @@ module.exports = {
         'sw': 'Bidhaa ulizo agiza\n $orders \n1) kudhibitisha'
     },
     'final_message': {
-        'en-ke': 'Thank you for placing your Just in Time Top-up order.',
-        'sw': 'Asante kwa kutuma maombi yako ya Just in Time Top-up.'
+        'en-ke': 'Thanks for ordering $products. Thank you for topping-up through JiT.',
+        'sw': 'Asante kwa kujisajili na $produts. Asante kwa kutuma maombi yako ya Just in Time Top-up.'
     },
     'variety_confirmation': {
         'en-ke': 'Top-up with $bundleName and $inputName\n1) Confirm\n2) Cancel',


### PR DESCRIPTION
update to send an SMS to the stored client's phone number in addition to the phone being used when placing an order for  just in time [SER-9](https://oneacrefund.atlassian.net/secure/RapidBoard.jspa?rapidView=83&selectedIssue=SER-9), update the content to include the ordered products as well 

To test: Dial on this service [here](https://telerivet.com/p/0c6396c9/service/SVb47209de1fdd2cf0/edit) 

- Enter a GL account: **24450523**
- Choose 5 for top-up on the net menu
- Enter an account number in the same group: **27507822** or **27507840**
- Place any order and finalize
- Confirm
- Two SMS should be sent (on the phone being used and Angello's Kenya SIM)
