### PR TITLE
fix SeasonName undefined error

### DIFF
--- a/ke-legacy/main.js
+++ b/ke-legacy/main.js
@@ -1030,8 +1030,8 @@ var NonClientMenuTextWithMsg = function (msg) {
 };
 
 var PaymentMenuText = function (client){
-    var repaid = GetRepaid (client, client.BalanceHistory[0].SeasonName);
-    var balance = GetBalance(client, client.BalanceHistory[0].SeasonName);
+    var repaid = client.BalanceHistory.length > 0 ? GetRepaid (client, client.BalanceHistory[0].SeasonName) : 0;
+    var balance = client.BalanceHistory.length > 0 ? GetBalance(client, client.BalanceHistory[0].SeasonName) : 0;
     if (GetLang()){sayText('You are paying into account number '+client.AccountNumber+' Total Repaid '+repaid+', Bal '+balance+'.Please reply with the amount you want to pay');}
     else {sayText('Unafanya malipo kwa hii akaunti '+client.AccountNumber+' Jumla ya malipo '+repaid+', Salio '+balance+'.Tafadhali weka kiasi unachotaka kulipa');}
 };


### PR DESCRIPTION
The error occurs when newly registered clients that have no balance history try to access the make payment menu item. 
It is safe to set the repaid and balance values to 0 when the balance history length is 0