### PR TITLE
HOTFIX-SER-244-remove special characters from names during registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file. 
 
+## 2020-09-29
+### Added
+
+[SER-244](https://oneacrefund.atlassian.net/browse/SER-244)Make sure new clients can't register with special characters in their names
+
+
 ## 2020-09-23
 ### Added
 

--- a/client-registration/first-name-handler/firstNameHandler.js
+++ b/client-registration/first-name-handler/firstNameHandler.js
@@ -5,6 +5,7 @@ module.exports = {
     handlerName: handlerName,
     getHandler: function(onFirstNameReceived){
         return function (input) {
+            input = input.replace(/[^a-zA-Z]/gi, '');
             notifyELK();
             onFirstNameReceived(input);
         };

--- a/client-registration/first-name-handler/firstNameHandler.test.js
+++ b/client-registration/first-name-handler/firstNameHandler.test.js
@@ -13,8 +13,14 @@ describe('firstNameHandler', () => {
         expect(getHandler(onFirstNameReceived)).toBeInstanceOf(Function);
     });
     it('should call notifyELK ', () => {
-        firstNameHandler();
+        firstNameHandler('hello');
         expect(notifyELK).toHaveBeenCalled();
+    });
+    it('should remove special characters from the name', () => {
+        const handler  = getHandler(onFirstNameReceived);
+        const mockInput = 'hellO1 \' `*1& ^_ ';
+        handler(mockInput);
+        expect(onFirstNameReceived).toHaveBeenCalledWith('hellO');
     });
     it('should call the onFirstNameReceived callback when the returned value is called', () => {
         const handler  = getHandler(onFirstNameReceived);

--- a/client-registration/second-name-handler/secondNameHandler.js
+++ b/client-registration/second-name-handler/secondNameHandler.js
@@ -4,6 +4,7 @@ module.exports = {
     handlerName: handlerName,
     getHandler: function(onSecondNameReceived){
         return function (input) {
+            input = input.replace(/[^a-zA-Z]/gi, '');
             onSecondNameReceived(input);
         };
     }

--- a/client-registration/second-name-handler/secondNameHandler.test.js
+++ b/client-registration/second-name-handler/secondNameHandler.test.js
@@ -9,6 +9,12 @@ describe('secondNameHandler', () => {
     it('should return a function', () => {
         expect(getHandler(onSecondNameReceived)).toBeInstanceOf(Function);
     });
+    it('should remove special characters from the name', () => {
+        const handler  = getHandler(onSecondNameReceived);
+        const mockInput = 'hellO1 \' `*1& ^_ ';
+        handler(mockInput);
+        expect(onSecondNameReceived).toHaveBeenCalledWith('hellO');
+    });
     
     it('should call the onSecondNameReceived callback when the returned value is called', () => {
         const handler  = getHandler(onSecondNameReceived);

--- a/rw-legacy/core.js
+++ b/rw-legacy/core.js
@@ -825,6 +825,7 @@ addInputHandler('enr_reg_start', inputHandlers['registration_start']);
 addInputHandler('enr_nid_client_confirmation', function (input) {
     notifyELK();
     state.vars.current_step = 'enr_nid_client_confirmation';
+    
     input = String(input.replace(/\D/g, ''));
 
     if (input == 99) {
@@ -917,6 +918,7 @@ addInputHandler('enr_nid_client_confirmation', function (input) {
 
 
 inputHandlers['name1InputHandler'] = function (input) {
+    input = input.replace(/[^a-zA-Z]/gi, '');
     notifyELK();
     state.vars.current_step = 'enr_name_1';
     if (input == 99) {
@@ -944,6 +946,7 @@ inputHandlers['name1InputHandler'] = function (input) {
 addInputHandler('enr_name_1', inputHandlers['name1InputHandler']);
 
 inputHandlers['name2InputHandler'] = function (input) {
+    input = input.replace(/[^a-zA-Z]/gi, '');
     notifyELK();
     state.vars.current_step = 'enr_name_2';
     if (input == 99) {


### PR DESCRIPTION
This PR adds names validations before making a call to roster registration API, to avoid special characters which currently leads to errors