### PR TITLE
HOT-FIX duka client registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file. 
 
+## 2020-10-02
+### Fixed
+[SER-258](https://oneacrefund.atlassian.net/browse/SER-258) Duka Registration users not receiving SMSs
+When registering a new user, account number SMSs are not sent to clients.
 
 ## 2020-10-02
 ### Fixed
@@ -12,7 +16,6 @@ Before the newly registered client could not place an order because of their acc
 [SER-208](https://oneacrefund.atlassian.net/browse/SER-208) As a non-client, I want to register via USSD, so that I can purchase avocado trees through OAF
 
 Before the groupId was not saved in the registration table. this fixes it
-fixed the main menu issue, 0 is not recognized as an input for the first menu, replaced the option 0 with 1 and 1 with 2 on the first menu
 
 ## 2020-10-01
 ### Fixed

--- a/duka-client/registration/inputHandlers/accountNumberInputHandler.js
+++ b/duka-client/registration/inputHandlers/accountNumberInputHandler.js
@@ -63,8 +63,7 @@ module.exports = {
                         });
                         return;
                     } else {
-                        // get client from duka
-                        var nonDukaAccountMessagereprompt = getMessage('non_duka_account', {}, lang);
+                        var nonDukaAccountMessagereprompt = getMessage('duka_client_already_created', {}, lang);
                         global.sayText(nonDukaAccountMessagereprompt);
                         global.promptDigits(handlerName, {
                             submitOnHash: false,

--- a/duka-client/registration/inputHandlers/accountNumberInputHandler.js
+++ b/duka-client/registration/inputHandlers/accountNumberInputHandler.js
@@ -49,6 +49,7 @@ module.exports = {
                             content: messageToClient, 
                             to_number: dcr_duka_client.phoneNumber
                         });
+                        console.log('duka client registered. Sent message: ' + messageToClient + ' to: ' + JSON.stringify(dcr_duka_client));
                         if(state.vars.dcr_credit > 0) {
                             global.sayText(getMessage('outstanding_balance', {'$balance': state.vars.dcr_credit}, lang));
                             global.stopRules();
@@ -62,6 +63,7 @@ module.exports = {
                         });
                         return;
                     } else {
+                        // get client from duka
                         var nonDukaAccountMessagereprompt = getMessage('non_duka_account', {}, lang);
                         global.sayText(nonDukaAccountMessagereprompt);
                         global.promptDigits(handlerName, {
@@ -95,7 +97,7 @@ module.exports = {
                             state.vars.account_number = accountNumber;
                             state.vars.phone_number = client.PhoneNumber;
                             // has paid everything
-                            global.sayText(getMessage('enter_invoice_id', {}, lang));
+                            global.sayText(getMessage('already_duka_client', {}, lang));
                             global.promptDigits(invoiceIdInputHandler.handlerName, {
                                 submitOnHash: false
                             });

--- a/duka-client/registration/inputHandlers/accountNumberInputHandler.test.js
+++ b/duka-client/registration/inputHandlers/accountNumberInputHandler.test.js
@@ -193,8 +193,8 @@ describe.each(['en-ke', 'sw'])('Farmer\' account number input handler', (lang) =
         contact.phone_number = '0722334535';
         getClient.mockReturnValueOnce(clientWithDukaDistrict);
         const messages = {
-            'en-ke': 'Please reply with the client\'s Erply Invoice ID',
-            'sw': 'Tafadhali jibu na Kitambulisho cha mteja cha Erply Invoice'
+            'en-ke': 'You\'re already registered for a duka district. Please enter the client\'s invoice ID.',
+            'sw': 'Umesajiliwa kwa wilaya ya duka. Tafadhali ingiza nambari ya Invoice ya mteja'
         };
         const accountNumberHandler = accountNumberInputHandler.getHandler(lang, 'dev_credit_officers_table');
         accountNumberHandler('12345678');

--- a/duka-client/registration/inputHandlers/accountNumberInputHandler.test.js
+++ b/duka-client/registration/inputHandlers/accountNumberInputHandler.test.js
@@ -111,8 +111,8 @@ describe.each(['en-ke', 'sw'])('Farmer\' account number input handler', (lang) =
         });
         const accountNumberHandler = accountNumberInputHandler.getHandler(lang);
         const messages = {
-            'en-ke': 'You\'ve entered an account number for a non-duka account. Enter your duka account number or 0 to register as a duka client.',
-            'sw': 'Umeingiza nambari ya akaunti isiyo ya duka. Ingiza nambari yako ya akaunti ya duka au \'0\' ili ujiandikishe kama mteja wa duka.'
+            'en-ke': 'You\'re already registered for a duka district. Please enter the client\'s duka account',
+            'sw': 'Umesajiliwa kwa wilaya ya duka. Tafadhali ingiza nambari ya Akaunti ya duka'
         };
         accountNumberHandler(0);
         expect(sayText).toHaveBeenCalledWith(messages[lang]);

--- a/duka-client/registration/inputHandlers/confirmFirstSecondNameInputHandler.js
+++ b/duka-client/registration/inputHandlers/confirmFirstSecondNameInputHandler.js
@@ -41,6 +41,7 @@ module.exports = {
                         content: messageToClient, 
                         to_number: state.vars.duka_client_phone_number
                     });
+                    console.log('duka client registered. Sent message: ' + messageToClient + ' to: ' + state.vars.duka_client_phone_number);
                     global.stopRules();
                 } else {
                     var Log = new logger();

--- a/duka-client/registration/inputHandlers/confirmInvoiceIdInputHandler.js
+++ b/duka-client/registration/inputHandlers/confirmInvoiceIdInputHandler.js
@@ -11,6 +11,7 @@ module.exports = {
             notifyElk();
             var getMessage = translator(translations, lang);
             if(input == 1) {
+                console.log('state variables: ==>' + JSON.stringify(state.vars));
                 if(state.vars.duka_client_first_name) {
                     var confirmFirstSecondName = require('./confirmFirstSecondNameInputHandler');
                     var confirmNamesMessageTitle = getMessage('first_sencond_name_confirm', {

--- a/duka-client/registration/inputHandlers/firstNameInputHandler.js
+++ b/duka-client/registration/inputHandlers/firstNameInputHandler.js
@@ -8,7 +8,7 @@ module.exports = {
     handlerName: handlerName,
     getHandler: function(lang) {
         return function(input) {
-            input = input.replace(/[^a-zA-Z]/gi, '');
+            input = input.replace(/[^a-zA-Z0-9]/gi, '');
             notifyElk();
             var secondNameInputHandler = require('./secondNameInputHandler');
             var getMessage = translator(translations, lang);

--- a/duka-client/registration/inputHandlers/firstNameInputHandler.js
+++ b/duka-client/registration/inputHandlers/firstNameInputHandler.js
@@ -10,8 +10,13 @@ module.exports = {
         return function(input) {
             input = input.replace(/[^a-zA-Z0-9]/gi, '');
             notifyElk();
-            var secondNameInputHandler = require('./secondNameInputHandler');
             var getMessage = translator(translations, lang);
+            if(!input) {
+                global.sayText(getMessage('enter_first_name', {}, lang));
+                global.promptDigits(handlerName);
+                return;
+            }
+            var secondNameInputHandler = require('./secondNameInputHandler');
             state.vars.duka_client_first_name = input;
             var secondNamePrompt = getMessage('enter_second_name', {}, lang);
             global.sayText(secondNamePrompt);

--- a/duka-client/registration/inputHandlers/firstNameInputHandler.test.js
+++ b/duka-client/registration/inputHandlers/firstNameInputHandler.test.js
@@ -4,7 +4,7 @@ const notifyElk = require('../../../notifications/elk-notification/elkNotificati
 
 jest.mock('../../../notifications/elk-notification/elkNotification');
 describe.each(['en-ke', 'sw'])('first name input handler', (lang) => {
-    it('should prompt the user for first name once the phone number is valid', () => {
+    it('should prompt the user for the second name once the first name is valid', () => {
         const handler = firstNameInputHandler.getHandler(lang);
         const message = {
             'sw': 'Tafadhali jibu na jina la pili la mteja.',
@@ -16,4 +16,18 @@ describe.each(['en-ke', 'sw'])('first name input handler', (lang) => {
         expect(state.vars.duka_client_first_name).toEqual('Jamie1');
         expect(promptDigits).toHaveBeenCalledWith(secondNameInputHandler.handlerName);
     });
+
+    it('should reprompt for the first name once the input is invalid', () => {
+        const handler = firstNameInputHandler.getHandler(lang);
+        const message = {
+            'en-ke': 'Please reply with the first name of the client.',
+            'sw': 'Tafadhali jibu na jina la kwanza la mteja.'
+        };
+        handler('`*& ^_ ');
+        expect(notifyElk).toHaveBeenCalled();
+        expect(sayText).toHaveBeenCalledWith(message[lang]);
+        expect(promptDigits).toHaveBeenCalledWith(firstNameInputHandler.handlerName);
+    });
+
+    
 });

--- a/duka-client/registration/inputHandlers/firstNameInputHandler.test.js
+++ b/duka-client/registration/inputHandlers/firstNameInputHandler.test.js
@@ -13,7 +13,7 @@ describe.each(['en-ke', 'sw'])('first name input handler', (lang) => {
         handler('Jamie \' `*1& ^_ ');
         expect(notifyElk).toHaveBeenCalled();
         expect(sayText).toHaveBeenCalledWith(message[lang]);
-        expect(state.vars.duka_client_first_name).toEqual('Jamie');
+        expect(state.vars.duka_client_first_name).toEqual('Jamie1');
         expect(promptDigits).toHaveBeenCalledWith(secondNameInputHandler.handlerName);
     });
 });

--- a/duka-client/registration/inputHandlers/secondNameInputHandler.js
+++ b/duka-client/registration/inputHandlers/secondNameInputHandler.js
@@ -12,6 +12,12 @@ module.exports = {
             notifyElk();
             var invoiceIdInputHandler = require('./invoiceIdInputHandler');
             var getMessage = translator(translations, lang);
+
+            if(!input) {
+                global.sayText(getMessage('enter_second_name', {}, lang));
+                global.promptDigits(handlerName);
+                return;
+            }
             state.vars.duka_client_second_name = input;
             var promptInvoiceIdMessage = getMessage('enter_invoice_id', {}, lang);
             global.sayText(promptInvoiceIdMessage);

--- a/duka-client/registration/inputHandlers/secondNameInputHandler.js
+++ b/duka-client/registration/inputHandlers/secondNameInputHandler.js
@@ -8,7 +8,7 @@ module.exports = {
     handlerName: handlerName,
     getHandler: function(lang) {
         return function(input) {
-            input = input.replace(/[^a-zA-Z]/gi, '');
+            input = input.replace(/[^a-zA-Z0-9]/gi, '');
             notifyElk();
             var invoiceIdInputHandler = require('./invoiceIdInputHandler');
             var getMessage = translator(translations, lang);

--- a/duka-client/registration/inputHandlers/secondNameInputHandler.test.js
+++ b/duka-client/registration/inputHandlers/secondNameInputHandler.test.js
@@ -14,7 +14,7 @@ describe.each(['en-ke', 'sw'])('first name input handler', (lang) => {
         handler('Fox \' `*1& ^_ ');
         expect(notifyElk).toHaveBeenCalled();
         expect(sayText).toHaveBeenCalledWith(message[lang]);
-        expect(state.vars.duka_client_second_name).toEqual('Fox');
+        expect(state.vars.duka_client_second_name).toEqual('Fox1');
         expect(promptDigits).toHaveBeenCalledWith(invoiceIdInputHandler.handlerName);
     });
 });

--- a/duka-client/registration/inputHandlers/secondNameInputHandler.test.js
+++ b/duka-client/registration/inputHandlers/secondNameInputHandler.test.js
@@ -4,7 +4,7 @@ const notifyElk = require('../../../notifications/elk-notification/elkNotificati
 
 jest.mock('../../../notifications/elk-notification/elkNotification');
 describe.each(['en-ke', 'sw'])('first name input handler', (lang) => {
-    it('should prompt the user for first name once the phone number is valid', () => {
+    it('should prompt the user for invoice id if the second name is valid', () => {
         const handler = secondNameInputHandler.getHandler(lang);
         const message = {
             'sw': 'Tafadhali jibu na Kitambulisho cha mteja cha Erply Invoice',
@@ -16,5 +16,18 @@ describe.each(['en-ke', 'sw'])('first name input handler', (lang) => {
         expect(sayText).toHaveBeenCalledWith(message[lang]);
         expect(state.vars.duka_client_second_name).toEqual('Fox1');
         expect(promptDigits).toHaveBeenCalledWith(invoiceIdInputHandler.handlerName);
+    });
+
+    
+    it('should reprompt for the second name once the input is invalid', () => {
+        const handler = secondNameInputHandler.getHandler(lang);
+        const message = {
+            'en-ke': 'Please reply with the second name of the client.',
+            'sw': 'Tafadhali jibu na jina la pili la mteja.'
+        };
+        handler('`*& ^_ ');
+        expect(notifyElk).toHaveBeenCalled();
+        expect(sayText).toHaveBeenCalledWith(message[lang]);
+        expect(promptDigits).toHaveBeenCalledWith(secondNameInputHandler.handlerName);
     });
 });

--- a/duka-client/registration/translations/index.js
+++ b/duka-client/registration/translations/index.js
@@ -66,5 +66,9 @@ module.exports = {
     'successfull_transaction': {
         'en-ke': 'You have successfully recorded your transaction.',
         'sw': 'Umekamilisha mafanikio ya ununuzi wako.'
+    },
+    'already_duka_client': {
+        'en-ke': 'You\'re already registered for a duka district. Please enter the client\'s invoice ID.',
+        'sw': 'Umesajiliwa kwa wilaya ya duka. Tafadhali ingiza nambari ya Invoice ya mteja'
     }
 };

--- a/duka-client/registration/translations/index.js
+++ b/duka-client/registration/translations/index.js
@@ -70,5 +70,9 @@ module.exports = {
     'already_duka_client': {
         'en-ke': 'You\'re already registered for a duka district. Please enter the client\'s invoice ID.',
         'sw': 'Umesajiliwa kwa wilaya ya duka. Tafadhali ingiza nambari ya Invoice ya mteja'
+    },
+    'duka_client_already_created': {
+        'en-ke': 'You\'re already registered for a duka district. Please enter the client\'s duka account',
+        'sw': 'Umesajiliwa kwa wilaya ya duka. Tafadhali ingiza nambari ya Akaunti ya duka'
     }
 };


### PR DESCRIPTION
TEST FROM [HERE](https://telerivet.com/p/0c6396c9/service/SV7684c662f118f82e/edit)

### new client
- dial is the short code
- enter a credit officer id: 1234
- choose register client (option 1)
- choose 0 for new client
- respond to all prompts
(national id is any 7 or 8 digits number)
- for others you can enter any generic input.
for the sake of demoing the sms sent, you can put the simulator phone(555-0123) when prompted for phone so that the simulator will receive the sms.
user should be registered and sms should be sent notifying the user of their new account number.

### existing OAF client with a duka account number
- dial in the short code
- enter the officer id (1234)
- choose register client (option 1)
- enter the account number (27508860)
- there comes a notice that a client is not a duka district client
- choose 0 attempting to register them as duka district clients
- you should see a notice that the user is already associated with some duka district account and be prompted to add their duka district account number.
- add their duka client account (27508883)
- you get prompted of invoice id.
- add any generic number and confirm.
-a row should be created in the data table dev_duka_client_registration with the user details
