### PR TITLE
hotfix- fixing the rwanda main menu issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Before the newly registered client could not place an order because of their acc
 [SER-208](https://oneacrefund.atlassian.net/browse/SER-208) As a non-client, I want to register via USSD, so that I can purchase avocado trees through OAF
 
 Before the groupId was not saved in the registration table. this fixes it
+fixed the main menu issue, 0 is not recognized as an input for the first menu, replaced the option 0 with 1 and 1 with 2 on the first menu
 
 ## 2020-10-01
 ### Fixed

--- a/rw-legacy/core.js
+++ b/rw-legacy/core.js
@@ -109,12 +109,13 @@ global.main = function () {
 };
 
 addInputHandler('main_menu_splash',function(input){
+    notifyELK();
     input = String(input.replace(/\D/g, ''));
-    if(input == 0){
+    if(input == 1){
         clientRegistration.start(0,'RW',lang);
         stopRules();
     }
-    else if(input == 1){
+    else if(input == 2){
         sayText(msgs('cor_enr_main_splash',{},lang));
         promptDigits('account_number_splash', {
             'submitOnHash': false,

--- a/rw-legacy/lib/utils/message-translations.js
+++ b/rw-legacy/lib/utils/message-translations.js
@@ -708,8 +708,8 @@ module.exports = {
         "ki": "Murakaza neza muri TUBURA. Andika nimero ya konti y'umuhinzi",
     },
     "main_menu":{
-        'en': 'Welcome to One Acre Fund Tubura.\n0) Not currently a client\n1) Already a client',
-        'ki': 'Urakaza neza muri Tubura. Andika\n0) Niba udasanzwe uri umukiriya wa Tubura\n1) Niba usanzwe uri umukiriya wa Tubura'
+        'en': 'Welcome to One Acre Fund Tubura.\n1) Not currently a client\n2) Already a client',
+        'ki': 'Urakaza neza muri Tubura. Andika\n1) Niba udasanzwe uri umukiriya wa Tubura\n2) Niba usanzwe uri umukiriya wa Tubura'
     },
     "ENR_FINALIZE_TERMS_AND_CONDITION": {
         "en": "I enroll in TUBURA by agreeing on TUBURA loan Terms and Conditions and I will sign it on the day of input pickup. ~B 1) Continue ~B 2) Quit",


### PR DESCRIPTION
Before the first menu for Rwanda core was:
 Welcome to One Acre Fund Tubura.\n**0**) Not currently a client\n**1**) Already a client
changed it:
 to Welcome to One Acre Fund Tubura.\n**1**) Not currently a client\n**2**) Already a client**

It looks like 0 doesn't work on the first menu

If you have a Rwanda SIM you can test it on develop : \*801\*15# (old code)
or on the shortcode \*801\*13#(this branch)