### PR TITLE
SER-268-added saving the diference between the orders to another column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file. 
 
+## 2020-10-06
+### Added
+
+[SER-268](https://oneacrefund.atlassian.net/secure/RapidBoard.jspa?rapidView=83&selectedIssue=SER-268) - Add a column to save the difference in the avocado intead of overwriting the old One
+
 ## 2020-10-05
 ### Added
 

--- a/avocado-trees-ordering/avocadoTreesOrdering.js
+++ b/avocado-trees-ordering/avocadoTreesOrdering.js
@@ -79,14 +79,14 @@ function onOrderConfirmed(){
         var avocadoCursor = avocado_table.queryRows({'vars': {'account_number': state.vars.account}});
         if(avocadoCursor.hasNext()){
             var avocadoRow = avocadoCursor.next();
-            avocadoRow.vars.a_avokaqty = state.vars.orderedNumber;
+            avocadoRow.vars.avoka_jit = (state.vars.orderedNumber - avocadoRow.vars.a_avokaqty);
             avocadoRow.vars.confirmed = '1';
             avocadoRow.save();
         }
         else{
             var new_avocado_row = avocado_table.createRow({
                 vars: {
-                    'a_avokaqty': state.vars.orderedNumber,
+                    'avoka_jit': state.vars.orderedNumber,
                     'account_number': state.vars.account,
                     'confirmed': '1'
                 }

--- a/avocado-trees-ordering/avocadoTreesOrdering.test.js
+++ b/avocado-trees-ordering/avocadoTreesOrdering.test.js
@@ -157,7 +157,7 @@ describe('avocadoServices',()=>{
             mockCursor.hasNext.mockReturnValueOnce(false).mockReturnValueOnce(true);
             callback();
             expect(mockTable.createRow).toHaveBeenCalledWith({vars: {
-                'a_avokaqty': state.vars.orderedNumber,
+                'avoka_jit': state.vars.orderedNumber,
                 'account_number': state.vars.account,
                 'confirmed': '1'
             }});


### PR DESCRIPTION
Save the difference between the ordered avocado and what the user just confirmed in a separate column instead of overwriting the old column
To test: https://telerivet.com/p/8799a79f/service/SV1161debc042a9de0/edit

- enter 2 on the first menu for returning client
- use the account number: 27842919
- choose option 7(order avocado)
- order any amount of avocado greater than 3
- confirm the order
**the avoka_jit column should be updated with the difference between the a_avokaqty( ordered quantity) column and the value confirmed**  [here](https://telerivet.com/p/8799a79f/data/dev_5Favocado_5Ftable?sort=&f[vars.account_number]=27842919)