### PR TITLE
THD-3170-fixed getFOInfo return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file. 
 
+
+## 2020-10-08
+### Fixed
+
+[THD-3170] (https://oneacrefund.atlassian.net/browse/THD-3170) - Include two confirmation SMSes for the USSD Registration service
+fixed the issue of sending sms with FO contact when available
+
 ## 2020-10-05
 ### Added
 

--- a/Roster-endpoints/Fo-info/getFoInfo.js
+++ b/Roster-endpoints/Fo-info/getFoInfo.js
@@ -11,7 +11,7 @@ module.exports = function (districtId,siteId) {
     try {
         response = httpClient.request(fullUrl, opts);
         if (response.status == 200) {
-            return response.content;
+            return JSON.parse(response.content);
         }
         else {
             var logger = new Log();

--- a/Roster-endpoints/Fo-info/getFoInfo.test.js
+++ b/Roster-endpoints/Fo-info/getFoInfo.test.js
@@ -35,7 +35,7 @@ describe('getFoInfo', () => {
         );
     });
     it('should return Fo info if the request is succesful', () => {
-        httpClient.request.mockReturnValueOnce({status: 200, content: mockResult});
+        httpClient.request.mockReturnValueOnce({status: 200, content: JSON.stringify(mockResult)});
         const result = getFoInfo(mockRequestData.districtId,mockRequestData.siteId);
         expect(result).toEqual(mockResult);
     });


### PR DESCRIPTION
Fixed the issue of sending an SMS with FO contact

To test here:  https://telerivet.com/p/0c6396c9/service/SVc3c8d451e239d756/edit

- use 24450523 as account number
- choose 3 for client registration
- choose 0 for a new client
- enter any 8 digits national ID, 
- enter 0712301351 as phone number
- finalize registration
- an SMS should be sent with FO contact


the same step bringing the FO contact here: https://telerivet.com/p/0c6396c9/service/SVbc04709b5abb48c0/edit
