### PR TITLE
hotfix-update the registration endpoint to match the endpoint change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file. 
 
+## 2020-10-09
+### Fixed
+
+[THD-3213] (https://oneacrefund.atlassian.net/browse/THD-3213) Wrong Account Generation
+Updated the the registration service to match it's endpoint. AccountNumber is now returned as a key value pair instead of just a string when there is a national Id conflict 
+
 ## 2020-10-08
 ### Fixed
 

--- a/rw-legacy/lib/roster/register-client.js
+++ b/rw-legacy/lib/roster/register-client.js
@@ -43,19 +43,27 @@ module.exports = function (clientJSON, lang) {
         }
         else if (response.status == 409) {
             logResponse(fullUrl, response);
-            var accountNumber = parseInt(response.content.replace(/\"/g, ' '));
-            if((isNaN(accountNumber)) || (accountNumber == null) || (typeof(accountNumber) == undefined)){
+            //If the account number is returned in the content, return it to the user
+            if(JSON.parse(response.content).AccountNumber){
+                var accountNumber = parseInt(JSON.parse(response.content).AccountNumber.replace(/\"/g, ' '));
+                if((isNaN(accountNumber)) || (accountNumber == null) || (typeof(accountNumber) == undefined)){
+                    sayText(msgs('FAILURE_REGISTERING', {}, lang));
+                    if(logger) logger.warn('Error Registering a new Client',{tags: [service.vars.env],data: response});
+                    stopRules();
+                    return null;
+                }
+                else{
+                    sayText(msgs('enrolled_national_id', {'$AccountNumber': accountNumber}, lang));
+                    stopRules();
+                    return null;
+                }
+            }  
+            else{
                 sayText(msgs('FAILURE_REGISTERING', {}, lang));
                 if(logger) logger.warn('Error Registering a new Client',{tags: [service.vars.env],data: response});
                 stopRules();
                 return null;
-            }
-            else{
-                sayText(msgs('enrolled_national_id', {'$AccountNumber': accountNumber}, lang));
-                stopRules();
-                return null;
-            }
-            
+            }  
         }
         else {
             logResponse(fullUrl, response);


### PR DESCRIPTION
Updated the registration service to reflect the changes of its endpoint(returning the account number as a key-value instead of a string)

To test it here: https://telerivet.com/p/0c6396c9/service/SVc3c8d451e239d756/edit
- use the account number 24450523
- choose option 3 to register a client
- Enter 0 for a new client
- Enter an already registered national ID:3198116
- Continue with the registration process, for the phone number you can use: 0712301351
- An message with the registered account number should be displayed on the phone  