### PR TITLE
Add "XXXXXXX" to the second name automatically

### DIFF
--- a/client-registration/second-name-handler/secondNameHandler.js
+++ b/client-registration/second-name-handler/secondNameHandler.js
@@ -5,6 +5,9 @@ module.exports = {
     getHandler: function(onSecondNameReceived){
         return function (input) {
             input = input.replace(/[^a-zA-Z]/gi, '');
+            if (state.vars.country == 'RW' && !input) {
+                input = 'XXXXXXX';
+            }
             onSecondNameReceived(input);
         };
     }

--- a/client-registration/second-name-handler/secondNameHandler.js
+++ b/client-registration/second-name-handler/secondNameHandler.js
@@ -4,7 +4,7 @@ module.exports = {
     handlerName: handlerName,
     getHandler: function(onSecondNameReceived){
         return function (input) {
-            input = input.replace(/[^a-zA-Z]/gi, '');
+            input = input.replace(/[^a-zA-Z0-9]/gi, '');
             if (state.vars.country == 'RW' && !input) {
                 input = 'XXXXXXX';
             }

--- a/client-registration/second-name-handler/secondNameHandler.test.js
+++ b/client-registration/second-name-handler/secondNameHandler.test.js
@@ -1,5 +1,7 @@
 const {getHandler} = require('./secondNameHandler');
 
+const defaultSecondName = 'XXXXXXX';
+
 describe('secondNameHandler', () => {
     let onSecondNameReceived;
     beforeEach(() => {
@@ -15,7 +17,20 @@ describe('secondNameHandler', () => {
         handler(mockInput);
         expect(onSecondNameReceived).toHaveBeenCalledWith('hellO');
     });
-    
+    it('should revert to default for empty name', () => {
+        state.vars.country = 'RW';
+        const handler  = getHandler(onSecondNameReceived);
+        const mockInput = '';
+        handler(mockInput);
+        expect(onSecondNameReceived).toHaveBeenCalledWith(defaultSecondName);
+    });
+    it('should revert to default for only special character names', () => {
+        state.vars.country = 'RW';
+        const handler  = getHandler(onSecondNameReceived);
+        const mockInput = '\' `*1& ^_ ';
+        handler(mockInput);
+        expect(onSecondNameReceived).toHaveBeenCalledWith(defaultSecondName);
+    });
     it('should call the onSecondNameReceived callback when the returned value is called', () => {
         const handler  = getHandler(onSecondNameReceived);
         const mockInput = 'hello';

--- a/client-registration/second-name-handler/secondNameHandler.test.js
+++ b/client-registration/second-name-handler/secondNameHandler.test.js
@@ -17,19 +17,26 @@ describe('secondNameHandler', () => {
         handler(mockInput);
         expect(onSecondNameReceived).toHaveBeenCalledWith('hellO');
     });
-    it('should revert to default for empty name', () => {
+    it('should revert to default for empty name in RW', () => {
         state.vars.country = 'RW';
         const handler  = getHandler(onSecondNameReceived);
         const mockInput = '';
         handler(mockInput);
         expect(onSecondNameReceived).toHaveBeenCalledWith(defaultSecondName);
     });
-    it('should revert to default for only special character names', () => {
+    it('should revert to default for only special character names in RW', () => {
         state.vars.country = 'RW';
         const handler  = getHandler(onSecondNameReceived);
         const mockInput = '\' `*1& ^_ ';
         handler(mockInput);
         expect(onSecondNameReceived).toHaveBeenCalledWith(defaultSecondName);
+    });
+    it('should remove special characters from the name in RW', () => {
+        state.vars.country = 'RW';
+        const handler  = getHandler(onSecondNameReceived);
+        const mockInput = 'hellO1 \' `*1& ^_ ';
+        handler(mockInput);
+        expect(onSecondNameReceived).toHaveBeenCalledWith('hellO');
     });
     it('should call the onSecondNameReceived callback when the returned value is called', () => {
         const handler  = getHandler(onSecondNameReceived);

--- a/client-registration/second-name-handler/secondNameHandler.test.js
+++ b/client-registration/second-name-handler/secondNameHandler.test.js
@@ -15,7 +15,7 @@ describe('secondNameHandler', () => {
         const handler  = getHandler(onSecondNameReceived);
         const mockInput = 'hellO1 \' `*1& ^_ ';
         handler(mockInput);
-        expect(onSecondNameReceived).toHaveBeenCalledWith('hellO');
+        expect(onSecondNameReceived).toHaveBeenCalledWith('hellO11');
     });
     it('should revert to default for empty name in RW', () => {
         state.vars.country = 'RW';
@@ -27,7 +27,7 @@ describe('secondNameHandler', () => {
     it('should revert to default for only special character names in RW', () => {
         state.vars.country = 'RW';
         const handler  = getHandler(onSecondNameReceived);
-        const mockInput = '\' `*1& ^_ ';
+        const mockInput = '\' `*& ^_ ';
         handler(mockInput);
         expect(onSecondNameReceived).toHaveBeenCalledWith(defaultSecondName);
     });
@@ -36,7 +36,7 @@ describe('secondNameHandler', () => {
         const handler  = getHandler(onSecondNameReceived);
         const mockInput = 'hellO1 \' `*1& ^_ ';
         handler(mockInput);
-        expect(onSecondNameReceived).toHaveBeenCalledWith('hellO');
+        expect(onSecondNameReceived).toHaveBeenCalledWith('hellO11');
     });
     it('should call the onSecondNameReceived callback when the returned value is called', () => {
         const handler  = getHandler(onSecondNameReceived);

--- a/rw-legacy/core.js
+++ b/rw-legacy/core.js
@@ -949,7 +949,7 @@ inputHandlers['name1InputHandler'] = function (input) {
 addInputHandler('enr_name_1', inputHandlers['name1InputHandler']);
 
 inputHandlers['name2InputHandler'] = function (input) {
-    input = input.replace(/[^a-zA-Z]/gi, '');
+    input = input.replace(/[^a-zA-Z0-9]/gi, '');
     notifyELK();
     state.vars.current_step = 'enr_name_2';
     if (input == 99) {
@@ -958,20 +958,16 @@ inputHandlers['name2InputHandler'] = function (input) {
         stopRules();
         return null;
     }
-    input = input.replace(/[^a-z_]/ig, '');
+    input = input.replace(/[^a-zA-Z0-9_]/ig, '');
     if (contact.phone_number == '5550123') { // allows for testing on the online testing env
         input = 'TestSecondName';
     }
-    if (input === undefined || input == '') {
-        sayText(msgs('enr_invalid_name_input', {}, lang));
-        promptDigits('enr_name_2', { 'submitOnHash': false, 'maxDigits': max_digits_for_name, 'timeout': timeout_length });
-    }
-    else {
-        regSessionManager.save(contact.phone_number, state.vars, 'name2InputHandler', input);
-        state.vars.reg_name_2 = input;
-        sayText(msgs('enr_pn', {}, lang));
-        promptDigits('enr_pn', { 'submitOnHash': false, 'maxDigits': max_digits_for_pn, 'timeout': timeout_length });
-    }
+    input = input ? input : 'XXXXXXX';
+
+    regSessionManager.save(contact.phone_number, state.vars, 'name2InputHandler', input);
+    state.vars.reg_name_2 = input;
+    sayText(msgs('enr_pn', {}, lang));
+    promptDigits('enr_pn', { 'submitOnHash': false, 'maxDigits': max_digits_for_pn, 'timeout': timeout_length });
     get_time();
 };
 addInputHandler('enr_name_2', inputHandlers['name2InputHandler']);


### PR DESCRIPTION
### Testing
Service: https://telerivet.com/p/8799a79f/service/SV0990ef3092d2c138/edit
1. Dial \*801\*13#
2. Enter 1 to select the _Not currently a client_ option
3. Enter a 16 digit national ID
4. Enter 1 to confirm the national ID
5. Enter first name
6. Enter a **non-alphanumeric string** as second name
7. Complete the rest of the enrolment steps
8. The client should be registered with the second name set to `XXXXXX` 