### PR TITLE
HOTFIX-Ser 274 update duka registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file. 
 
+## 2020-10-16
+### Added
+
+[SER-274] (https://oneacrefund.atlassian.net/browse/SER-274) - Add layaway to the USSD enrollment app for the Dukas
+
 ## 2020-10-09
 ### Fixed
 

--- a/duka-client/registration/inputHandlers/accountNumberInputHandler.js
+++ b/duka-client/registration/inputHandlers/accountNumberInputHandler.js
@@ -4,7 +4,7 @@ var getClient = require('../../../shared/rosterApi/getClient');
 var getPhoneNumbers = require('../../../shared/rosterApi/getPhoneNumber');
 var registerClient = require('../../../shared/rosterApi/registerClient');
 var nationalIdInputHandler = require('./nationalIdInputHandler');
-var invoiceIdInputHandler = require('./invoiceIdInputHandler');
+var transactionTypeInputHandler = require('./transactionTypeInputHandler');
 var notifyElk = require('../../../notifications/elk-notification/elkNotification');
 
 var handlerName = 'DCAccNumOrnewClient'; 
@@ -57,8 +57,8 @@ module.exports = {
                         }
                         state.vars.account_number = registeredClient.AccountNumber;
                         state.vars.phone_number = dcr_duka_client.phoneNumber;
-                        global.sayText(getMessage('enter_invoice_id', {}, lang));
-                        global.promptDigits(invoiceIdInputHandler.handlerName, {
+                        global.sayText(getMessage('transaction_type', {}, lang));
+                        global.promptDigits(transactionTypeInputHandler.handlerName, {
                             submitOnHash: false
                         });
                         return;
@@ -96,8 +96,8 @@ module.exports = {
                             state.vars.account_number = accountNumber;
                             state.vars.phone_number = client.PhoneNumber;
                             // has paid everything
-                            global.sayText(getMessage('already_duka_client', {}, lang));
-                            global.promptDigits(invoiceIdInputHandler.handlerName, {
+                            global.sayText(getMessage('transaction_type', {}, lang));
+                            global.promptDigits(transactionTypeInputHandler.handlerName, {
                                 submitOnHash: false
                             });
                         }

--- a/duka-client/registration/inputHandlers/accountNumberInputHandler.test.js
+++ b/duka-client/registration/inputHandlers/accountNumberInputHandler.test.js
@@ -3,7 +3,7 @@ const getClient = require('../../../shared/rosterApi/getClient');
 const registerClient = require('../../../shared/rosterApi/registerClient');
 const getPhoneNumbers = require('../../../shared/rosterApi/getPhoneNumber');
 const nationalIdInputHandler = require('./nationalIdInputHandler');
-const invoiceIdInputHandler = require('./invoiceIdInputHandler');
+var transactionTypeInputHandler = require('./transactionTypeInputHandler');
 const notifyElk = require('../../../notifications/elk-notification/elkNotification');
 
 jest.mock('../../../shared/rosterApi/getClient');
@@ -64,8 +64,8 @@ describe.each(['en-ke', 'sw'])('Farmer\' account number input handler', (lang) =
             district: 'credit_officer_details.district'
         });
         const messages = {
-            'en-ke': 'Please reply with the client\'s Erply Invoice ID',
-            'sw': 'Tafadhali jibu na Kitambulisho cha mteja cha Erply Invoice'
+            'en-ke': 'Is this a credit or layaway transaction?\n1) Credit\n2) Layaway',
+            'sw': 'Je hii ni shughuli ya mkopo wa Credit au Layaway?\n1) Credit\n2) Layaway'
         };
         const sms = {
             'en-ke': 'Thank you for registering with OAF. Your Account Number is 27507544. The Duka team will help you complete your loan.',
@@ -76,7 +76,7 @@ describe.each(['en-ke', 'sw'])('Farmer\' account number input handler', (lang) =
         accountNumberHandler(0);
         expect(project.sendMessage).toHaveBeenCalledWith({'content': sms[lang], 'to_number': '07887654376'});
         expect(sayText).toHaveBeenCalledWith(messages[lang]);
-        expect(promptDigits).toHaveBeenCalledWith( invoiceIdInputHandler.handlerName, {'submitOnHash': false}); 
+        expect(promptDigits).toHaveBeenCalledWith( transactionTypeInputHandler.handlerName, {'submitOnHash': false}); 
         expect(state.vars.account_number).toEqual('27507544');
         expect(state.vars.phone_number).toEqual('07887654376');
     });
@@ -193,12 +193,12 @@ describe.each(['en-ke', 'sw'])('Farmer\' account number input handler', (lang) =
         contact.phone_number = '0722334535';
         getClient.mockReturnValueOnce(clientWithDukaDistrict);
         const messages = {
-            'en-ke': 'You\'re already registered for a duka district. Please enter the client\'s invoice ID.',
-            'sw': 'Umesajiliwa kwa wilaya ya duka. Tafadhali ingiza nambari ya Invoice ya mteja'
+            'en-ke': 'Is this a credit or layaway transaction?\n1) Credit\n2) Layaway',
+            'sw': 'Je hii ni shughuli ya mkopo wa Credit au Layaway?\n1) Credit\n2) Layaway'
         };
         const accountNumberHandler = accountNumberInputHandler.getHandler(lang, 'dev_credit_officers_table');
         accountNumberHandler('12345678');
         expect(sayText).toHaveBeenCalledWith(messages[lang]);
-        expect(promptDigits).toHaveBeenCalledWith(invoiceIdInputHandler.handlerName, {'submitOnHash': false});
+        expect(promptDigits).toHaveBeenCalledWith(transactionTypeInputHandler.handlerName, {'submitOnHash': false});
     });
 });

--- a/duka-client/registration/inputHandlers/confirmFirstSecondNameInputHandler.js
+++ b/duka-client/registration/inputHandlers/confirmFirstSecondNameInputHandler.js
@@ -32,7 +32,8 @@ module.exports = {
                         vars: {
                             'invoice_id': state.vars.duka_client_invoice_id,
                             'account_number': accountNumber,
-                            'phone_number': state.vars.duka_client_phone_number
+                            'phone_number': state.vars.duka_client_phone_number,
+                            'transaction_type': state.vars.transaction_type
                         }
                     });
                     row.save();

--- a/duka-client/registration/inputHandlers/confirmFirstSecondNameInputHandler.js
+++ b/duka-client/registration/inputHandlers/confirmFirstSecondNameInputHandler.js
@@ -20,7 +20,7 @@ module.exports = {
                     siteId: officer_details.site_id,
                     firstName: state.vars.duka_client_first_name,
                     lastName: state.vars.duka_client_second_name,
-                    nationalIdNumber: 'DUKA-' + state.vars.duka_client_nid,
+                    nationalIdNumber: state.vars.duka_client_nid,
                     phoneNumber: state.vars.duka_client_phone_number
                 };
                 var enrolledClient = registerClient(clientData);

--- a/duka-client/registration/inputHandlers/confirmInvoiceIdInputHandler.js
+++ b/duka-client/registration/inputHandlers/confirmInvoiceIdInputHandler.js
@@ -28,7 +28,8 @@ module.exports = {
                         vars: {
                             'invoice_id': state.vars.duka_client_invoice_id,
                             'account_number': state.vars.account_number,
-                            'phone_number': state.vars.phone_number
+                            'phone_number': state.vars.phone_number,
+                            'transaction_type': state.vars.transaction_type
                         }
                     });
                     row.save();

--- a/duka-client/registration/inputHandlers/secondNameInputHandler.js
+++ b/duka-client/registration/inputHandlers/secondNameInputHandler.js
@@ -10,7 +10,7 @@ module.exports = {
         return function(input) {
             input = input.replace(/[^a-zA-Z0-9]/gi, '');
             notifyElk();
-            var invoiceIdInputHandler = require('./invoiceIdInputHandler');
+            var transactionTypeInputHandler = require('./transactionTypeInputHandler');
             var getMessage = translator(translations, lang);
 
             if(!input) {
@@ -19,9 +19,9 @@ module.exports = {
                 return;
             }
             state.vars.duka_client_second_name = input;
-            var promptInvoiceIdMessage = getMessage('enter_invoice_id', {}, lang);
+            var promptInvoiceIdMessage = getMessage('transaction_type', {}, lang);
             global.sayText(promptInvoiceIdMessage);
-            global.promptDigits(invoiceIdInputHandler.handlerName);
+            global.promptDigits(transactionTypeInputHandler.handlerName);
         };
     }
 };

--- a/duka-client/registration/inputHandlers/secondNameInputHandler.test.js
+++ b/duka-client/registration/inputHandlers/secondNameInputHandler.test.js
@@ -1,5 +1,5 @@
 const secondNameInputHandler = require('./secondNameInputHandler');
-const invoiceIdInputHandler = require('./invoiceIdInputHandler');
+var transactionTypeInputHandler = require('./transactionTypeInputHandler');
 const notifyElk = require('../../../notifications/elk-notification/elkNotification');
 
 jest.mock('../../../notifications/elk-notification/elkNotification');
@@ -7,15 +7,15 @@ describe.each(['en-ke', 'sw'])('first name input handler', (lang) => {
     it('should prompt the user for invoice id if the second name is valid', () => {
         const handler = secondNameInputHandler.getHandler(lang);
         const message = {
-            'sw': 'Tafadhali jibu na Kitambulisho cha mteja cha Erply Invoice',
-            'en-ke': 'Please reply with the client\'s Erply Invoice ID'
+            'sw': 'Je hii ni shughuli ya mkopo wa Credit au Layaway?\n1) Credit\n2) Layaway',
+            'en-ke': 'Is this a credit or layaway transaction?\n1) Credit\n2) Layaway'
         };
         state.vars.duka_client_first_name = 'Jamie';
         handler('Fox \' `*1& ^_ ');
         expect(notifyElk).toHaveBeenCalled();
         expect(sayText).toHaveBeenCalledWith(message[lang]);
         expect(state.vars.duka_client_second_name).toEqual('Fox1');
-        expect(promptDigits).toHaveBeenCalledWith(invoiceIdInputHandler.handlerName);
+        expect(promptDigits).toHaveBeenCalledWith(transactionTypeInputHandler.handlerName);
     });
 
     

--- a/duka-client/registration/inputHandlers/transactionTypeInputHandler.js
+++ b/duka-client/registration/inputHandlers/transactionTypeInputHandler.js
@@ -1,0 +1,29 @@
+var translations = require('../translations/index');
+var translator = require('../../../utils/translator/translator');
+var notifyElk = require('../../../notifications/elk-notification/elkNotification');
+var invoiceIdInputHandler = require('./invoiceIdInputHandler');
+var handlerName = 'dcr_transaction_type_handler';
+var transactionTypes = {
+    '1': 'Credit',
+    '2': 'Layaway'
+};
+
+module.exports = {
+    handlerName: handlerName,
+    getHandler: function(lang) {
+        return function(input) {
+            notifyElk();
+            var getMessage = translator(translations, lang);
+            var transactionType = transactionTypes[input];
+            if(transactionType) {
+                state.vars.transaction_type = transactionType;
+                global.sayText(getMessage('enter_invoice_id', {}, lang));
+                global.promptDigits(invoiceIdInputHandler.handlerName);
+            } else {
+                var transactionMessage = getMessage('transaction_type', {}, lang);
+                global.sayText(transactionMessage);
+                global.promptDigits(handlerName);
+            }
+        };
+    }
+};

--- a/duka-client/registration/inputHandlers/transactionTypeInputHandler.test.js
+++ b/duka-client/registration/inputHandlers/transactionTypeInputHandler.test.js
@@ -1,0 +1,39 @@
+const transactionTypeInputHandler = require('./transactionTypeInputHandler');
+const invoiceIdInputHandler = require('./invoiceIdInputHandler');
+
+describe.each(['en-ke', 'sw'])('Transaction type Input handler using (%s)', (lang) => {
+    it('should set a transaction type to credit and prompt for invoice number if the user chooses 1 --' + lang, () => {
+        const handler = transactionTypeInputHandler.getHandler(lang);
+        handler(1);
+        const messages = {
+            'en-ke': 'Please reply with the client\'s Erply Invoice ID',
+            'sw': 'Tafadhali jibu na Kitambulisho cha mteja cha Erply Invoice'
+        };
+        expect(state.vars.transaction_type).toEqual('Credit');
+        expect(sayText).toHaveBeenCalledWith(messages[lang]);
+        expect(promptDigits).toHaveBeenCalledWith(invoiceIdInputHandler.handlerName);
+    });
+
+    it('should set a transaction type to Layaway and prompt for invoice number if the user chooses 2 --' + lang, () => {
+        const handler = transactionTypeInputHandler.getHandler(lang);
+        handler(2);
+        const messages = {
+            'en-ke': 'Please reply with the client\'s Erply Invoice ID',
+            'sw': 'Tafadhali jibu na Kitambulisho cha mteja cha Erply Invoice'
+        };
+        expect(state.vars.transaction_type).toEqual('Layaway');
+        expect(sayText).toHaveBeenCalledWith(messages[lang]);
+        expect(promptDigits).toHaveBeenCalledWith(invoiceIdInputHandler.handlerName);
+    });
+
+    it('should reprompt the user for transaction type if the response is not 1 or 2 --' + lang, () => {
+        const handler = transactionTypeInputHandler.getHandler(lang);
+        handler('gucci');
+        const messages = {
+            'en-ke': 'Is this a credit or layaway transaction?\n1) Credit\n2) Layaway',
+            'sw': 'Je hii ni shughuli ya mkopo wa Credit au Layaway?\n1) Credit\n2) Layaway'
+        };
+        expect(sayText).toHaveBeenCalledWith(messages[lang]);
+        expect(promptDigits).toHaveBeenCalledWith(transactionTypeInputHandler.handlerName);
+    });
+});

--- a/duka-client/registration/registration.js
+++ b/duka-client/registration/registration.js
@@ -10,9 +10,11 @@ var secondNameInputHandler = require('./inputHandlers/secondNameInputHandler');
 var phoneNumberInputHandler = require('./inputHandlers/phoneNumberInputHandler');
 var invoiceInputHandler = require('./inputHandlers/invoiceIdInputHandler');
 var nationalIdInputHandler = require('./inputHandlers/nationalIdInputHandler');
+var transactionTypeInputHandler = require('./inputHandlers/transactionTypeInputHandler');
 
 function registerInputHandlers(lang, duka_clients_table) {
     addInputHandler(accountNumberInputHandler.handlerName, accountNumberInputHandler.getHandler(lang));
+    addInputHandler(transactionTypeInputHandler.handlerName, transactionTypeInputHandler.getHandler(lang));
     addInputHandler(confirmFirstSecondNameInputHandler.handlerName, confirmFirstSecondNameInputHandler.getHandler(lang,  duka_clients_table));
     addInputHandler(confirmInvoiceInputHandler.handlerName, confirmInvoiceInputHandler.getHandler(lang,  duka_clients_table));
     addInputHandler(confirmNidInputHandler.handlerName, confirmNidInputHandler.getHandler(lang));

--- a/duka-client/registration/registration.test.js
+++ b/duka-client/registration/registration.test.js
@@ -9,6 +9,7 @@ var secondNameInputHandler = require('./inputHandlers/secondNameInputHandler');
 var phoneNumberInputHandler = require('./inputHandlers/phoneNumberInputHandler');
 var invoiceInputHandler = require('./inputHandlers/invoiceIdInputHandler');
 var nationalIdInputHandler = require('./inputHandlers/nationalIdInputHandler');
+var transactionTypeInputHandler = require('./inputHandlers/transactionTypeInputHandler');
 
 describe.each(['en-ke', 'sw'])('duka client Registration using (%s)', (lang) => {
     it('should register all the registration input handlers --' + lang, () => {
@@ -22,6 +23,7 @@ describe.each(['en-ke', 'sw'])('duka client Registration using (%s)', (lang) => 
         var phoneNumberHandler = jest.fn();
         var invoiceHandler = jest.fn();
         var nationalIdHandler = jest.fn();
+        var transactionTypeHandler = jest.fn();
         
         jest.spyOn(accountNumberInputHandler, 'getHandler').mockReturnValueOnce(accountNumberHandler);
         jest.spyOn(confirmFirstSecondNameInputHandler, 'getHandler').mockReturnValueOnce(confirmFirstSecondNameHandler);
@@ -33,11 +35,13 @@ describe.each(['en-ke', 'sw'])('duka client Registration using (%s)', (lang) => 
         jest.spyOn(phoneNumberInputHandler, 'getHandler').mockReturnValueOnce(phoneNumberHandler);
         jest.spyOn(invoiceInputHandler, 'getHandler').mockReturnValueOnce(invoiceHandler);
         jest.spyOn(nationalIdInputHandler, 'getHandler').mockReturnValueOnce(nationalIdHandler);
+        jest.spyOn(transactionTypeInputHandler, 'getHandler').mockReturnValueOnce(transactionTypeHandler);
 
 
         registration.registerInputHandlers(lang, 'duka_clients_table');
 
         expect(addInputHandler).toHaveBeenCalledWith(accountNumberInputHandler.handlerName, accountNumberHandler);
+        expect(addInputHandler).toHaveBeenCalledWith(transactionTypeInputHandler.handlerName, transactionTypeHandler);
         expect(addInputHandler).toHaveBeenCalledWith(confirmFirstSecondNameInputHandler.handlerName, confirmFirstSecondNameHandler);
         expect(addInputHandler).toHaveBeenCalledWith(confirmInvoiceInputHandler.handlerName, confirmInvoiceHandler);
         expect(addInputHandler).toHaveBeenCalledWith(confirmNidInputHandler.handlerName, confirmNidHandler);

--- a/duka-client/registration/translations/index.js
+++ b/duka-client/registration/translations/index.js
@@ -74,5 +74,9 @@ module.exports = {
     'duka_client_already_created': {
         'en-ke': 'You\'re already registered for a duka district. Please enter the client\'s duka account',
         'sw': 'Umesajiliwa kwa wilaya ya duka. Tafadhali ingiza nambari ya Akaunti ya duka'
+    },
+    'transaction_type': {
+        'en-ke': 'Is this a credit or layaway transaction?\n1) Credit\n2) Layaway',
+        'sw': 'Je hii ni shughuli ya mkopo wa Credit au Layaway?\n1) Credit\n2) Layaway'
     }
 };


### PR DESCRIPTION
TEST FROM HERE https://telerivet.com/p/0c6396c9/service/SV7684c662f118f82e/edit

Dial in the short code:
- enter the credit officer code: 1234
- select 1 for registration
- enter account number:  non duka: **28126250**  or duka: **28126275 **
before implementing the changes, user received a prompt for invoice id but now,
- user receives a prompt to enter transaction type
- choose any of the two on the screen
- enter the invoice id: any number
- confirm
- a record should be created in https://telerivet.com/p/0c6396c9/data/dev_5Fduka_5Fclient_5Fregistration
with all user information

The same case for new clients.
- enter the credit officer code: 1234
- select 1 for registration
- choose zero for new client
- answer all prompts. after entering the second name, you should receive a prompt for transaction type
- respond with any of supported options on the screen
- after responding everything, a record should be created in the same table.