### PR TITLE
hotfix ser-335 allow duka districts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## New Version
 
+## v1.1.0
+### Added
+* [SER-335](https://oneacrefund.atlassian.net/browse/SER-335) Add Duka registration support for returning Duka clients
+
 ## v1.0.9
 ### Added
 * [SER-323](https://oneacrefund.atlassian.net/browse/SER-323) RW - Rearrange the products in the system

--- a/duka-client/registration/inputHandlers/accountNumberInputHandler.js
+++ b/duka-client/registration/inputHandlers/accountNumberInputHandler.js
@@ -96,7 +96,8 @@ module.exports = {
                     client.PhoneNumber = phone_number;
                     var outStandingCredit = OutstandingCredit(client.BalanceHistory);
                     state.vars.dcr_credit = outStandingCredit;
-                    if(client.SiteName == 'Duka'){
+                    
+                    if(client.SiteName == 'Duka' || client.DistrictName == 'OAF Duka'){
                         if(outStandingCredit > 0) {
                             // if has an out standing credit, ask them to pay the remaining amount
                             global.sayText(getMessage('outstanding_balance', {'$balance': outStandingCredit}, lang));

--- a/duka-client/registration/inputHandlers/accountNumberInputHandler.test.js
+++ b/duka-client/registration/inputHandlers/accountNumberInputHandler.test.js
@@ -187,6 +187,31 @@ describe.each(['en-ke', 'sw'])('Farmer\' account number input handler', (lang) =
         expect(sayText).toHaveBeenCalledWith(messages[lang]);
         expect(stopRules).toHaveBeenCalled();
     });
+    it('should notify the user if the duka client\'s account number has outstanding credit given that the site name is not duka and district name is OAF Duka', () => {
+        const clientWithDukaDistrict = {
+            DistrictName: 'OAF Duka',
+            SiteName: 'nay site',
+            FirstName: 'Aria',
+            LastName: 'Stark',
+            BalanceHistory: [
+                {Balance: 0},
+                {Balance: 4540},
+                {Balance: 3240}
+            ]
+        };
+        contact.phone_number = '0722334535';
+        getClient.mockReturnValueOnce(clientWithDukaDistrict);
+
+        const messages = {
+            'en-ke': 'You have a Duka credit account with an outstanding credit balance of 7780. Please complete your loan in order to take another one.',
+            'sw': 'Una akaunti ya mkopo ya Duka na salio bora la mkopo la X. Tafadhali kamilisha mkopo wako ili uchukue nyingine.'
+        };
+
+        const accountNumberHandler = accountNumberInputHandler.getHandler(lang);
+        accountNumberHandler('12345678');
+        expect(sayText).toHaveBeenCalledWith(messages[lang]);
+        expect(stopRules).toHaveBeenCalled();
+    });
 
     it('should the user for invoice id if the duka client\'s account number has no outstanding credit', () => {
         const clientWithDukaDistrict = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
allow accounts with the district name: OAF Duka

to test here: https://telerivet.com/p/0c6396c9/service/SV3c5034dacfc21c61/edit
- enter 1234 on the first menu
- enter 1 to register the client
- enter any account number on the ticket:
26916340
26916354
26916412
26916420
26916436
26916448
26916457
26916473
26916485
26916499
26916500

It should show a message confirming it's a duka account 