### PR TITLE
HOT-FIX SER-349 Change USSD response for core clients who would want to be enrolled at the Duka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 All notable changes to this project will be documented in this file. 
 
 ## New Version
-
+## v1.2.1
+### Fixed
+* [SER-349](https://oneacrefund.atlassian.net/browse/SER-349) Change USSD response for core clients who would want to be enrolled at the Duka
 ## v1.2.0
 ### Fixed
 * [SER-344](https://oneacrefund.atlassian.net/browse/SER-344) Adjust USSD non-client menu for Kenya

--- a/duka-client/registration/inputHandlers/accountNumberInputHandler.js
+++ b/duka-client/registration/inputHandlers/accountNumberInputHandler.js
@@ -59,11 +59,6 @@ module.exports = {
                         });
                         console.log('duka client registered. scheduled message for credit officer: ' + messageToClient + ' to: ' + contact.phone_number);
                         console.log('duka client registered. scheduled message for farmer: ' + messageToClient + ' to: ' + JSON.stringify(dcr_duka_client));
-                        if(state.vars.dcr_credit > 0) {
-                            global.sayText(getMessage('outstanding_balance', {'$balance': state.vars.dcr_credit}, lang));
-                            global.stopRules();
-                            return;
-                        }
                         state.vars.account_number = registeredClient.AccountNumber;
                         state.vars.phone_number = dcr_duka_client.phoneNumber;
                         global.sayText(getMessage('transaction_type', {}, lang));
@@ -95,7 +90,6 @@ module.exports = {
                     var phone_number = getActivePhoneNumber(accountNumber, country);
                     client.PhoneNumber = phone_number;
                     var outStandingCredit = OutstandingCredit(client.BalanceHistory);
-                    state.vars.dcr_credit = outStandingCredit;
                     
                     if(client.SiteName == 'Duka' || client.DistrictName == 'OAF Duka'){
                         if(outStandingCredit > 0) {

--- a/duka-client/registration/inputHandlers/accountNumberInputHandler.test.js
+++ b/duka-client/registration/inputHandlers/accountNumberInputHandler.test.js
@@ -91,26 +91,6 @@ describe.each(['en-ke', 'sw'])('Farmer\' account number input handler', (lang) =
         expect(state.vars.phone_number).toEqual('07887654376');
     });
 
-    it('should register the user to a duka district account once they already have an account number with OAF, and ask them to complete their debt once they have an outstanding credit', () => {
-        state.vars.dcr_duka_client = JSON.stringify({
-            FirstName: 'client.FirstName',
-            LastName: 'client.LastName',
-            PhoneNumber: 'client.PhoneNumber',
-            site: 'credit_officer_details.site',
-            district: 'credit_officer_details.district'
-        });
-        state.vars.dcr_credit = 4500;
-        const messages = {
-            'en-ke': 'You have a Duka credit account with an outstanding credit balance of 4500. Please complete your loan in order to take another one.',
-            'sw': 'Una akaunti ya mkopo ya Duka na salio bora la mkopo la 4500. Tafadhali kamilisha mkopo wako ili uchukue nyingine.'
-        };
-        registerClient.mockReturnValueOnce({});
-        const accountNumberHandler = accountNumberInputHandler.getHandler(lang);
-        accountNumberHandler(0);
-        expect(sayText).toHaveBeenCalledWith(messages[lang]);
-        expect(stopRules).toHaveBeenCalled(); 
-    });
-
     it('should reprompt for the account number once the user is not successfully registered', () => {
         state.vars.dcr_duka_client = JSON.stringify({
             FirstName: 'client.FirstName',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently when a credit officer registers a core client who has some loan to a duka district, they are told to complete that loan.

The correction is that we only require that for already existing duka clients who have loans.

testing: https://telerivet.com/p/0c6396c9/service/SV3c5034dacfc21c61/edit
- Dial in the shortcode
- Add the credit officer id: 1234
- Enter 1 for registration
- Add account number (`29304074`) the core client with credit
```  "BalanceHistory": [
    {
      "AccountGuid": "guid",
      "GroupId": 1270,
      "GroupName": "name",
      "SiteId": 19,
      "SiteName": "site name",
      "SeasonId": 280,
      "SeasonName": "season name",
      "SeasonStart": "2021-03-01T00:00:00",
      "TotalCredit": 14286.000,
      "TotalRepayment_IncludingOverpayments": 0.0000,
      "Balance": 14286.0000,
      "CurrencyCode": "KES"
    }

- Enter Zero (0) to register as a duka client
- The user should be registered successfully
- you can proceed with the following steps as usual