### PR TITLE
MOB-109 fix healthy path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## New Version
 
+### Fixed
+* [MOB-109](https://oneacrefund.atlassian.net/browse/MOB-109) Fix Healthy path calculation
 ### Changed
 * [SER-370](https://oneacrefund.atlassian.net/browse/SER-370) Verify Groups on Roster instead of using telerivet data tables
 * [MOB-128](https://oneacrefund.atlassian.net/browse/MOB-128) Repayment Services UAT fixes

--- a/healthy-path/balance/healthyPathOnBalance.js
+++ b/healthy-path/balance/healthyPathOnBalance.js
@@ -23,5 +23,5 @@ module.exports = function(SeasonId, CountryId, DistrictId, credit, repaid, lang)
         status = getMessage('status_above', {}, lang);
     }
     var message = getMessage('healthy_path_balance', {'$HP_DIST': Math.abs(healthyPathDistance), '$status': status}, lang);
-    return message;
+    return healthyPathDistance.toString() == 'NaN' ? '' : message;
 };

--- a/healthy-path/balance/healthyPathOnBalance.test.js
+++ b/healthy-path/balance/healthyPathOnBalance.test.js
@@ -14,4 +14,9 @@ describe('Healthy path on Balance screen', () => {
         var message = HealthyPathMessage(1, 2, 3, 150, 50, 'en');
         expect(message).toBe('Healthy Path Status: 5 above healthy path\n');
     });
+    it('should return an empty message when the user has not healthy path', () => {
+        fetchHealthyPathData.mockImplementationOnce(() => {});
+        var message = HealthyPathMessage(1, 2, 3, 150, 50, 'en');
+        expect(message).toBe('');
+    });
 });

--- a/healthy-path/repayments/HealthyPathOnRepaymentReceipts.js
+++ b/healthy-path/repayments/HealthyPathOnRepaymentReceipts.js
@@ -17,5 +17,5 @@ module.exports = function(SeasonId, CountryId, DistrictId, credit, repaid, lang)
     if(healthyPathDistance > 0) {
         message = getMessage('healthy_path_repayment', {'$HP_DIST': healthyPathDistance}, lang);
     }
-    return message;
+    return healthyPathDistance.toString() == 'NaN' ? '' : message;
 };

--- a/healthy-path/repayments/healthyPathOnRepayments.test.js
+++ b/healthy-path/repayments/healthyPathOnRepayments.test.js
@@ -15,4 +15,10 @@ describe('Healthy path on Repayments receipt', () => {
         var message = HealthyPathMessage(1, 2, 3, 150, 50, 'en');
         expect(message).toBe('');
     });
+
+    it('should return an empty message when the user has not healthy path', () => {
+        getHealthyPathPercentage.mockImplementationOnce(() => {});
+        var message = HealthyPathMessage(1, 2, 3, 150, 50, 'en');
+        expect(message).toBe('');
+    });
 });

--- a/healthy-path/utils/getHealthyPathPercentage.js
+++ b/healthy-path/utils/getHealthyPathPercentage.js
@@ -9,7 +9,7 @@ var getHealthyPathData = require('../../shared/rosterApi/getHealthyPathData');
  */
 module.exports = function(SeasonId, CountryId, DistrictId) {
     try {
-        var healthyPathData = getHealthyPathData(SeasonId, CountryId, DistrictId);
+        var healthyPathData = getHealthyPathData(SeasonId, CountryId, DistrictId) || [];
         var currentWeekHealthyPathData = healthyPathData.filter(function(entry) {
             var compareDate = moment();
             var startDate   = moment(entry.StartDate);

--- a/healthy-path/utils/getHealthyPathPercentage.test.js
+++ b/healthy-path/utils/getHealthyPathPercentage.test.js
@@ -46,5 +46,13 @@ describe('get healthy path percentage', () => {
         getHealthyPathData.mockReturnValueOnce(mockData);
         const result = getHealthyPathPercentage(1,2,3);
         expect(result).toEqual(0.55);
+    });
+
+    it('should not break if the healthy path is empty or not returned', () => {
+        jest.spyOn(slack, 'log');
+        getHealthyPathData.mockImplementationOnce(() => {});
+        const result = getHealthyPathPercentage(1,2,3);
+        expect(result).toEqual(undefined);
+        expect(slack.log).toHaveBeenCalledWith('API returned empty healthy path or an error during week number calculation{"content":[]}');
     }); 
 });

--- a/repayments-rw/repaymentsRw.js
+++ b/repayments-rw/repaymentsRw.js
@@ -1,8 +1,6 @@
 var translator = require('../utils/translator/translator');
 var translations = require('./translations/index');
-var getHealthyPathPercentage = require('../healthy-path/utils/getHealthyPathPercentage');
-var calculateHealthyPath= require('../healthy-path/utils/healthyPathCalculator');
-
+var getHealthyPathDist = require('../healthy-path/repayments/HealthyPathOnRepaymentReceipts');
 var defaultEnvironment; 
 if(service.active){
     defaultEnvironment = 'prod';
@@ -43,9 +41,7 @@ for (var i = 0; i < arrayLength; i++) {
 
 // calculating the healthy path
 var BalanceHistory = client.BalanceHistory[0];
-var healthyPathPercentage = getHealthyPathPercentage(BalanceHistory && BalanceHistory.SeasonId, client.CountryId, client.DistrictId);
-var healthyPath = calculateHealthyPath(healthyPathPercentage, BalanceHistory && BalanceHistory.TotalCredit, BalanceHistory && BalanceHistory.TotalRepayment_IncludingOverpayments);
-var hp_dist = healthyPath < 0 || !healthyPath ? '' : getMessage('hp_dist', {'$hp_dist': healthyPath}, 'ki');
+var hp_dist = getHealthyPathDist(BalanceHistory && BalanceHistory.SeasonId, client.CountryId, client.DistrictId, BalanceHistory && BalanceHistory.TotalCredit, BalanceHistory && BalanceHistory.TotalRepayment_IncludingOverpayments, 'ki');
 
 // sending the actual mm receipt
 var transactionLog = '';

--- a/repayments-rw/repaymentsRw.test.js
+++ b/repayments-rw/repaymentsRw.test.js
@@ -43,7 +43,7 @@ describe('Rwandan repayments', () => {
         'No y\'igikorwa: 123\n' +
         'No ya konti: 12345678\n' +
         'ayishyuwe yose 19A+B: 150 RWF\n' +
-        'Kanda *801*0# for more information\n' + 
+        'Kanda *801*0# kuyandi makuru\n' + 
         'Ishyura 300 ugume murongo mwiza w\'ubwishyu\n' , 'label_ids': ['123'], 'to_number': '0788445637'});
     });
 
@@ -60,7 +60,7 @@ describe('Rwandan repayments', () => {
         'Mwishyuye 320 RWF\n' +
         'No y\'igikorwa: 456\n' +
         'No ya konti: 87654321\n' +
-        'Kanda *801*0# for more information', 'label_ids': ['123'], 'to_number': '0788445637'});
+        'Kanda *801*0# kuyandi makuru\n', 'label_ids': ['123'], 'to_number': '0788445637'});
     });
 
 });

--- a/repayments-rw/translations/index.js
+++ b/repayments-rw/translations/index.js
@@ -1,11 +1,11 @@
 module.exports = {
     'mm_receipt_rw_0_paid': {
-        'en': '$LastName\nYou made a payment of $lastTransactionAmount RWF\nTxid: $lastTransactionId\nAccount #: $accountnumber\nDial*801*0# for more information',
-        'ki': '$LastName\nMwishyuye $lastTransactionAmount RWF\nNo y\'igikorwa: $lastTransactionId\nNo ya konti: $accountnumber\nKanda *801*0# for more information'
+        'en': '$LastName\nYou made a payment of $lastTransactionAmount RWF\nTxid: $lastTransactionId\nAccount #: $accountnumber\nDial*801*0# for more information\n',
+        'ki': '$LastName\nMwishyuye $lastTransactionAmount RWF\nNo y\'igikorwa: $lastTransactionId\nNo ya konti: $accountnumber\nKanda *801*0# kuyandi makuru\n'
     },
     'mm_receipt_rw_paid': {
-        'en': '$LastName\nYou made a payment of $lastTransactionAmount RWF\nTxid: $lastTransactionId\nAccount #: $accountnumber\nTotal repaid 19A+B: $paid RWF\nDial*801*0# for more information',
-        'ki': '$LastName\nMwishyuye $lastTransactionAmount RWF\nNo y\'igikorwa: $lastTransactionId\nNo ya konti: $accountnumber\nayishyuwe yose 19A+B: $paid RWF\nKanda *801*0# for more information'
+        'en': '$LastName\nYou made a payment of $lastTransactionAmount RWF\nTxid: $lastTransactionId\nAccount #: $accountnumber\nTotal repaid 19A+B: $paid RWF\nDial*801*0# for more information\n',
+        'ki': '$LastName\nMwishyuye $lastTransactionAmount RWF\nNo y\'igikorwa: $lastTransactionId\nNo ya konti: $accountnumber\nayishyuwe yose 19A+B: $paid RWF\nKanda *801*0# kuyandi makuru\n'
     },
     'hp_dist': {
         'en': '\nPay $hp_dist to stay on the healthy path.',

--- a/repayments/repayments.js
+++ b/repayments/repayments.js
@@ -3,8 +3,7 @@ var translator = require('../utils/translator/translator');
 var getPhoneNumber = require('../shared/rosterApi/getPhoneNumber');
 var logger = require('../slack-logger/index');
 var validateProjectVatiables = require('./validateProjectVariables');
-var getHealthyPathPercentage = require('../healthy-path/utils/getHealthyPathPercentage');
-var calculateHealthyPath= require('../healthy-path/utils/healthyPathCalculator');
+var getHealthyPathDist = require('../healthy-path/repayments/HealthyPathOnRepaymentReceipts');
 
 var defaultEnvironment; 
 if(service.active){
@@ -89,9 +88,7 @@ var mmReceipt = '';
 
 var repaymentsLabels = [languagesLabels[lang], 'MM receipt', 'Business Operations'];
 var BalanceHistory = client.BalanceHistory[0];
-var healthyPathPercentage = getHealthyPathPercentage(BalanceHistory && BalanceHistory.SeasonId, client.CountryId, client.DistrictId);
-var healthyPath = calculateHealthyPath(healthyPathPercentage, BalanceHistory && BalanceHistory.TotalCredit, BalanceHistory && BalanceHistory.TotalRepayment_IncludingOverpayments);
-var hp_dist = healthyPath < 0 ? '' : getMessage('hp_dist', {'$hp_dist': healthyPath}, lang);
+var hp_dist = getHealthyPathDist(BalanceHistory && BalanceHistory.SeasonId, client.CountryId, client.DistrictId, BalanceHistory && BalanceHistory.TotalCredit, BalanceHistory && BalanceHistory.TotalRepayment_IncludingOverpayments, lang);
 if (client.BalanceHistory[0].TotalRepayment_IncludingOverpayments > client.BalanceHistory[0].TotalCredit){
     var OverpaidAmount = client.BalanceHistory[0].TotalRepayment_IncludingOverpayments - client.BalanceHistory[0].TotalCredit;
     mmReceipt = getMessage('mm_receipt_over_paid', {

--- a/repayments/repayments.test.js
+++ b/repayments/repayments.test.js
@@ -120,7 +120,7 @@ describe('mobile money repayments using', () => {
             })
         };
         require('./repayments');
-        expect(project.sendMessage).toHaveBeenCalledWith({'content': 'Hello Je-3033-cf74-f94a Last payment: KSh 3000. Receipt Number 5beb94c0-3033-cf74-f94a. Total paid KSh 14000. Balance KSh 6500. Pay 1500 to stay on the healthy path.',
+        expect(project.sendMessage).toHaveBeenCalledWith({'content': 'Hello Je-3033-cf74-f94a Last payment: KSh 3000. Receipt Number 5beb94c0-3033-cf74-f94a. Total paid KSh 14000. Balance KSh 6500.Pay 1500 to stay on the healthy path\n',
             'to_number': '0755432334', 'label_ids': [
                 'lang',
                 'MM receipt',


### PR DESCRIPTION
when the healthy path result is empty the repayment and check balance information could fail or send a message containing NaN or undefined but now, when there is no healthy path returned, there is no healthy path message returned.