### PR TITLE
HOTFIX- MOB-156-Warehouse stock count debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file. 
 
 ## New Version
+
+## v1.6.2
+* [MOB-156](https://oneacrefund.atlassian.net/browse/MOB-156) Update the KE registration to check the warehouse stock
 ## v1.6.1
 ### Fixed
 * [MOB-146](https://oneacrefund.atlassian.net/browse/MOB-146) maize_recommendation was unable to automatically process an incoming SMS

--- a/client-enrollment/clientEnrollment.test.js
+++ b/client-enrollment/clientEnrollment.test.js
@@ -191,6 +191,24 @@ describe('clientRegistration', () => {
             clientEnrollment.start(account, country,enr_lang);
             expect(clientRegistration.onContinueToEnroll).toBeCalled();
         });
+        it('should save the  state.vars.varietyWarehouse if the variety warehouse is available', () => {
+            var {client}  = require('./test-client-with-loan');
+            client.BalanceHistory=[];
+            mockCursor.hasNext.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(wareHouseRow).mockReturnValueOnce(wareHouseRow);
+            roster.getClient = jest.fn().mockImplementationOnce(() => {return client ;});
+            clientEnrollment.start(account, country,enr_lang);
+            expect(state.vars.varietyWarehouse).toBe(wareHouseRow.vars.warehouse);
+        });
+        it('should set the  state.vars.varietyWarehouse to empty if warehouse is not available', () => {
+            var {client}  = require('./test-client-with-loan');
+            client.BalanceHistory=[];
+            mockCursor.hasNext.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false);
+            mockCursor.next.mockReturnValueOnce(wareHouseRow);
+            roster.getClient = jest.fn().mockImplementationOnce(() => {return client ;});
+            clientEnrollment.start(account, country,enr_lang);
+            expect(state.vars.varietyWarehouse).toBe(' ');
+        });
         it('should call not call continue to enroll if the wareHouse for that district is not found', () => {
             var {client}  = require('./test-client-with-loan');
             client.BalanceHistory=[];

--- a/client-registration/bundle-choice-handler/bundleChoiceHandler.test.js
+++ b/client-registration/bundle-choice-handler/bundleChoiceHandler.test.js
@@ -32,6 +32,7 @@ describe('order confirmation handler test', ()=>{
         bundleChoiceHandler(1);
         expect(state.vars.chosenMaizeBundle).toEqual(JSON.stringify(bundleArray[0]));
     });
+    
     it('should not call on bundle selected function function if the input from the user does  not correspond to a valid bundle',()=>{
         state.vars.multiple_input_menus = false;
         bundleChoiceHandler(3);
@@ -53,6 +54,20 @@ describe('order confirmation handler test', ()=>{
         bundleChoiceHandler(77);
         expect(sayText).toHaveBeenCalledWith(inputMenu[1]);
         expect(promptDigits).toHaveBeenCalledWith(handlerName);
+    });
+    it('should not display a menu page if the input is 77 and the next menu doesn\'t exists',()=>{
+        state.vars.multiple_input_menus = true;
+        state.vars.input_menu_loc = 3;
+        state.vars.input_menu_length = 3;
+        state.vars.input_menu = JSON.stringify(inputMenu);
+        bundleChoiceHandler(77);
+        expect(sayText).not.toHaveBeenCalled();
+    });
+    it('should not set  on state.vars.chosenMaizeBundle bundle if the quantity is not defined ',()=>{
+        state.vars.multiple_input_menus = false;
+        state.vars.chosenMaizeBundle = undefined;
+        bundleChoiceHandler(2);
+        expect(state.vars.chosenMaizeBundle).toBeUndefined();
     });
 
 

--- a/client-registration/clientRegistration.js
+++ b/client-registration/clientRegistration.js
@@ -64,7 +64,6 @@ module.exports = {
         function onContinueToEnroll(){
             displayBundles(JSON.parse(state.vars.newClient).DistrictId); 
             global.promptDigits(bundleChoiceHandler.handlerName);
-    
         }
         function onPhoneNumberConfirmed(){
             if(state.vars.country == 'RW'){
@@ -363,15 +362,11 @@ function onOrderConfirmed(){
         orderPlaced.forEach(function(element){
             var stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': element.bundleName}});
             if(stockCursor.hasNext()){
-                console.log('found');
                 var row = stockCursor.next();
                 row.vars.quantityordered =  row.vars.quantityordered + 1;
-                console.log('old quantity:--------------'+row.vars.quantityordered+ 'product:-----------'+element.bundleName+'warehouse:'+state.vars.warehouse+ service.vars.warehouseStockTableId);
                 row.save();
-            } 
-            console.log('old quantity:--------------0'+ 'product:-----------'+element.bundleName+'warehouse:'+state.vars.warehouse+ service.vars.warehouseStockTableId);
+            }
         });
-        console.log('no found');
         if(state.vars.chosenVariety != ' '){
             var varietyStockTable = project.initDataTableById(service.vars.varietyStockTableId);
             var stockCursor = varietyStockTable.queryRows({vars: {'warehousename': state.vars.varietyWarehouse,'inputname': JSON.parse(state.vars.chosenVariety).inputName}});
@@ -444,6 +439,7 @@ function displayBundles(district){
     var firstTime = true;
     var newBundle;
     var maizeTable = project.initDataTableById(service.vars.maizeEnrollmentTableId);
+    var bundleStockTable = project.initDataTableById(service.vars.warehouseStockTableId);
     var maizeCursor = maizeTable.queryRows();
 
     while(maizeCursor.hasNext()){
@@ -473,23 +469,47 @@ function displayBundles(district){
                                 newBundle.bundleName = '1 Maize Acre';
                                 newBundle.price = 8950;
                                 newBundle.quantity = 1;
-                                bundles.push(newBundle);
+                                var stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': newBundle.bundleName}});
+                                if(stockCursor.hasNext()){
+                                    var row = stockCursor.next();
+                                    if(row.vars.quantityavailable > row.vars.quantityordered){
+                                        bundles.push(newBundle);
+                                    }
+                                }
                                 newBundle = JSON.parse(JSON.stringify(bundleInputs[i]));
                                 newBundle.bundleName = '0.75 Maize Acre';
                                 newBundle.price = 7190;
                                 newBundle.quantity = 0.75;
-                                bundles.push(newBundle);
+                                stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': newBundle.bundleName}});
+                                if(stockCursor.hasNext()){
+                                    row = stockCursor.next();
+                                    if(row.vars.quantityavailable > row.vars.quantityordered){
+                                        bundles.push(newBundle);
+                                    }
+                                }
                                 newBundle = JSON.parse(JSON.stringify(bundleInputs[i]));
                                 newBundle.bundleName = '0.5 Maize Acre';
                                 newBundle.price = 4950;
                                 newBundle.quantity = 0.5;
-                                bundles.push(newBundle);
+                                stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': newBundle.bundleName}});
+                                if(stockCursor.hasNext()){
+                                    row = stockCursor.next();
+                                    if(row.vars.quantityavailable > row.vars.quantityordered){
+                                        bundles.push(newBundle);
+                                    }
+                                }
                                 bundleInputs[i].bundleName = '0.25 Maize Acre';
                                 bundleInputs[i].price = 2830;
                                 bundleInputs[i].quantity = 0.25;
                                 firstTime = false;
                             }
-                            bundles.push(bundleInputs[i]);
+                            stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': bundleInputs[i].bundleName}});
+                            if(stockCursor.hasNext()){
+                                row = stockCursor.next();
+                                if(row.vars.quantityavailable > row.vars.quantityordered){
+                                    bundles.push(bundleInputs[i]);
+                                }
+                            }
                         }
                     }
                     else{
@@ -498,23 +518,47 @@ function displayBundles(district){
                             newBundle.bundleName = '1 Maize Acre';
                             newBundle.price = 8950;
                             newBundle.quantity = 1;
-                            bundles.push(newBundle);
+                            stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': newBundle.bundleName}});
+                            if(stockCursor.hasNext()){
+                                row = stockCursor.next();
+                                if(row.vars.quantityavailable > row.vars.quantityordered){
+                                    bundles.push(newBundle);
+                                }
+                            }
                             newBundle = JSON.parse(JSON.stringify(bundleInputs[i]));
                             newBundle.bundleName = '0.75 Maize Acre';
                             newBundle.price = 7190;
                             newBundle.quantity = 0.75;
-                            bundles.push(newBundle);
+                            stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': newBundle.bundleName}});
+                            if(stockCursor.hasNext()){
+                                row = stockCursor.next();
+                                if(row.vars.quantityavailable > row.vars.quantityordered){
+                                    bundles.push(newBundle);
+                                }
+                            }
                             newBundle = JSON.parse(JSON.stringify(bundleInputs[i]));
                             newBundle.bundleName = '0.5 Maize Acre';
                             newBundle.price = 4950;
                             newBundle.quantity = 0.5;
-                            bundles.push(newBundle);
+                            stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': newBundle.bundleName}});
+                            if(stockCursor.hasNext()){
+                                row = stockCursor.next();
+                                if(row.vars.quantityavailable > row.vars.quantityordered){
+                                    bundles.push(newBundle);
+                                }
+                            }
                             bundleInputs[i].bundleName = '0.25 Maize Acre';
                             bundleInputs[i].price = 2830;
                             bundleInputs[i].quantity = 0.25;
                             firstTime = false;
                         }
-                        bundles.push(bundleInputs[i]);
+                        stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': bundleInputs[i].bundleName}});
+                        if(stockCursor.hasNext()){
+                            row = stockCursor.next();
+                            if(row.vars.quantityavailable > row.vars.quantityordered){
+                                bundles.push(bundleInputs[i]);
+                            }
+                        }
                     }
                 }
                 unique[bundleInputs[i].bundleId] = 1;

--- a/client-registration/clientRegistration.js
+++ b/client-registration/clientRegistration.js
@@ -363,11 +363,15 @@ function onOrderConfirmed(){
         orderPlaced.forEach(function(element){
             var stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': element.bundleName}});
             if(stockCursor.hasNext()){
+                console.log('found');
                 var row = stockCursor.next();
                 row.vars.quantityordered =  row.vars.quantityordered + 1;
+                console.log('old quantity:--------------'+row.vars.quantityordered+ 'product:-----------'+element.bundleName+'warehouse:'+state.vars.warehouse+ service.vars.warehouseStockTableId);
                 row.save();
             } 
+            console.log('old quantity:--------------0'+ 'product:-----------'+element.bundleName+'warehouse:'+state.vars.warehouse+ service.vars.warehouseStockTableId);
         });
+        console.log('no found');
         if(state.vars.chosenVariety != ' '){
             var varietyStockTable = project.initDataTableById(service.vars.varietyStockTableId);
             var stockCursor = varietyStockTable.queryRows({vars: {'warehousename': state.vars.varietyWarehouse,'inputname': JSON.parse(state.vars.chosenVariety).inputName}});

--- a/client-registration/clientRegistration.test.js
+++ b/client-registration/clientRegistration.test.js
@@ -60,6 +60,7 @@ var foPhone = '0786192039';
 var mockedTable = { queryRows: jest.fn()};
 var mockedRow = {hasNext: jest.fn(), next: jest.fn(),vars: {'national_id': nationalId,'account_number': account}};
 var mockRows = [{vars: {'bundleId': '-2009','bundleInputId': '-1709','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input'}},{vars: {'bundleId': '-9009','bundleInputId': '-5709','bundle_name': 'third possible name bundle','price': '6251','input_name': 'third input'}},{vars: {'bundleId': '-1009','bundleInputId': '-8709','bundle_name': 'fourth possible name bundle','price': '5251','input_name': 'fourth input'}},{vars: {'bundleId': '-2009','bundleInputId': '-18909','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input'}}];
+var mockWareHouseRows = [{vars: {'bundleId': '-2009','bundleInputId': '-1709','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input','quantityavailable': 10,'quantityordered': 2}},{vars: {'bundleId': '-9009','bundleInputId': '-5709','bundle_name': 'third possible name bundle','price': '6251','input_name': 'third input','quantityavailable': 10,'quantityordered': 2}},{vars: {'bundleId': '-1009','bundleInputId': '-8709','bundle_name': 'fourth possible name bundle','price': '5251','input_name': 'fourth input','quantityavailable': 10,'quantityordered': 2}},{vars: {'bundleId': '-2009','bundleInputId': '-18909','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input','quantityavailable': 10,'quantityordered': 2}}];
 var mockFirstRow = {vars: {'bundleId': '-3009','bundleInputId': '-12109','bundle_name': 'Knapsack Sprayer','price': '2251','input_name': 'Knapsack Sprayer'}};
 var mockBundleRow = {vars: {'bundleId': '-3009','bundleInputId': '-12109','bundle_name': 'Knapsack Sprayer','price': '2251','input_name': 'Knapsack Sprayer'}};
 var mockMaizeRows = [{vars: {'bundleId': '-2009','bundleInputId': '-1709','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input'}},{vars: {'bundleId': '-9009','bundleInputId': '-5709','bundle_name': 'third possible name bundle','price': '6251','input_name': 'third input'}}];
@@ -788,23 +789,94 @@ describe('clientRegistration', () => {
             callback = continueHandler.getHandler.mock.calls[0][0];                
         });
         it('should display the maize bundle size(1, 0.75, 0.5, 0.25) of maize bundles if a maize bundle is available',()=>{
-            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true);
-            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]);//.mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]);
             state.vars.orders = ' ';
             callback();
             expect(state.vars.bundles).toEqual(JSON.stringify(orders));
         });
         it('should display the maize bundle size(0.5 and 0.25) of maize bundles if a maize bundle is available and the client ordered other bundles than maize',()=>{
-            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true);
-            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]);//.mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
             state.vars.orders = JSON.stringify(mockRows[1]);
             callback();
             expect(state.vars.bundles).toEqual(JSON.stringify(orders));
         });
-        
+        it('should display the whole maize bundles if the menu chosen allow enrollment',()=>{
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
+            callback();
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockFirstRow.vars.bundle_name}`+
+            ` ${mockBundleRow.vars.price}`+
+            '\n2) 1 Maize Acre 8950\n3) 0.75 Maize Acre 7190\n4) 0.5 Maize Acre 4950\n5) 0.25 Maize Acre 2830\n');
+        });
         it('should display the bundles if the menu choosed allow enrollment',()=>{
-            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
-            mockCursor.next.mockReturnValueOnce(mockBundleRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[1]).mockReturnValueOnce(mockRows[2]);
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false);
+            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
+            callback();
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockFirstRow.vars.bundle_name}`+
+            ` ${mockBundleRow.vars.price}`+
+            '\n2) 1 Maize Acre 8950\n3) 0.75 Maize Acre 7190\n4) 0.5 Maize Acre 4950\n');
+        });
+        it('should display the maize bundles(1,0.75,0.25) if the variety stock allows only those',()=>{
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
+            callback();
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockFirstRow.vars.bundle_name}`+
+            ` ${mockBundleRow.vars.price}`+
+            '\n2) 1 Maize Acre 8950\n3) 0.75 Maize Acre 7190\n4) 0.25 Maize Acre 2830\n');
+        });
+        it('should display the maize bundles(1,0.5,0.25) if the variety stock allows only those',()=>{
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
+            callback();
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockFirstRow.vars.bundle_name}`+
+            ` ${mockBundleRow.vars.price}`+
+            '\n2) 1 Maize Acre 8950\n3) 0.5 Maize Acre 4950\n4) 0.25 Maize Acre 2830\n');
+        });
+        it('should display the maize bundles(0.75,0.5,0.25) if the variety stock allows only those',()=>{
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
+            callback();
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockFirstRow.vars.bundle_name}`+
+            ` ${mockBundleRow.vars.price}`+
+            '\n2) 0.75 Maize Acre 7190\n3) 0.5 Maize Acre 4950\n4) 0.25 Maize Acre 2830\n');
+        });
+        it('should display the maize bundles(0.5,0.25) if the variety stock allows only those',()=>{
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
+            callback();
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockFirstRow.vars.bundle_name}`+
+            ` ${mockBundleRow.vars.price}`+
+            '\n2) 0.5 Maize Acre 4950\n3) 0.25 Maize Acre 2830\n');
+        });
+        it('should display the maize bundles(0.75,0.25) if the variety stock allows only those',()=>{
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockWareHouseRows[0]);//.mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
+            callback();
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockFirstRow.vars.bundle_name}`+
+            ` ${mockBundleRow.vars.price}`+
+            '\n2) 0.75 Maize Acre 7190\n3) 0.25 Maize Acre 2830\n');
+        });
+        it('should display the maize bundles(1,0.25) if the variety stock allows only those',()=>{
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(false).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]);
+            callback();
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockFirstRow.vars.bundle_name}`+
+            ` ${mockBundleRow.vars.price}`+
+            '\n2) 1 Maize Acre 8950\n3) 0.25 Maize Acre 2830\n');
+        });
+        it('should display the maize bundles(1) if if the variety stock allows only those',()=>{
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(false).mockReturnValueOnce(false);
+            mockCursor.next.mockReturnValueOnce(mockFirstRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[0]);
+            callback();
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockFirstRow.vars.bundle_name}`+
+            ` ${mockBundleRow.vars.price}`+
+            '\n2) 1 Maize Acre 8950\n');
+        });
+        it('should display the bundles if the menu choosed allow enrollment',()=>{
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockBundleRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[1]).mockReturnValueOnce(mockRows[2]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[1]).mockReturnValueOnce(mockWareHouseRows[2]).mockReturnValueOnce(mockWareHouseRows[3]);
             callback();
             expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockBundleRow.vars.bundle_name}`+
             ` ${mockBundleRow.vars.price}`+
@@ -814,11 +886,9 @@ describe('clientRegistration', () => {
             ` ${mockRows[1].vars.price}`+
             '\n77)Next page');
         });
-
         it('should display only unique bundles(if two bundle inputs in the same bundle are found) and if the prepayment condition is satified ', () => {
-
-            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
-            mockCursor.next.mockReturnValueOnce(mockBundleRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[3]);
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockBundleRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[3]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[3]).mockReturnValueOnce(mockWareHouseRows[3]);
             callback();
             expect(sayText).not.toHaveBeenCalledWith(expect.stringContaining('You do not qualify for a top up,'));
             expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockBundleRow.vars.bundle_name}`+
@@ -828,16 +898,42 @@ describe('clientRegistration', () => {
             '\n');
         });
         it('should remove maize bundles from the displayed bundles if the prepayment condition is satisfied and the client already choosed a maize bundle',()=>{
-            
-            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true);
-            mockCursor.next.mockReturnValueOnce(mockBundleRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[1]).mockReturnValueOnce(mockMaizeRows[0]).mockReturnValueOnce(mockMaizeRows[1]);
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockBundleRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[1]).mockReturnValueOnce(mockWareHouseRows[1]).mockReturnValueOnce(mockWareHouseRows[0]);
             state.vars.orders = JSON.stringify([mockMaizeRows[0]]);
             callback();
             expect(sayText).not.toHaveBeenCalledWith(expect.stringContaining('You do not qualify for a top up,'));
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockRows[0].vars.bundle_name}`+
+            ` ${mockRows[0].vars.price}`+
+            `\n2) ${mockBundleRow.vars.bundle_name}`+
+            ` ${mockBundleRow.vars.price}`+
+            '\n');
+        });
+        it('should not display unavailable bundles ',()=>{
+            var mockWareHouseUnavailableRows = [{vars: {'bundleId': '-2009','bundleInputId': '-1709','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input','quantityavailable': 10,'quantityordered': 10}},{vars: {'bundleId': '-9009','bundleInputId': '-5709','bundle_name': 'third possible name bundle','price': '6251','input_name': 'third input','quantityavailable': 10,'quantityordered': 10}},{vars: {'bundleId': '-1009','bundleInputId': '-8709','bundle_name': 'fourth possible name bundle','price': '5251','input_name': 'fourth input','quantityavailable': 2,'quantityordered': 2}},{vars: {'bundleId': '-2009','bundleInputId': '-18909','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input','quantityavailable': 10,'quantityordered': 12}}];
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockBundleRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[1]).mockReturnValueOnce(mockRows[2]).mockReturnValueOnce(mockWareHouseUnavailableRows[0]).mockReturnValueOnce(mockWareHouseUnavailableRows[1]).mockReturnValueOnce(mockWareHouseUnavailableRows[2]).mockReturnValueOnce(mockWareHouseUnavailableRows[3]);
+            callback();
+            expect(state.vars.main_menu).toEqual('Select a product\n');
+        });
+        it('should display only available bundles if the menu choosed allow enrollment',()=>{
+            var mockWareHouseUnavailableRows = [{vars: {'bundleId': '-2009','bundleInputId': '-1709','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input','quantityavailable': 10,'quantityordered': 10}},{vars: {'bundleId': '-9009','bundleInputId': '-5709','bundle_name': 'third possible name bundle','price': '6251','input_name': 'third input','quantityavailable': 10,'quantityordered': 10}},{vars: {'bundleId': '-1009','bundleInputId': '-8709','bundle_name': 'fourth possible name bundle','price': '5251','input_name': 'fourth input','quantityavailable': 2,'quantityordered': 2}},{vars: {'bundleId': '-2009','bundleInputId': '-18909','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input','quantityavailable': 10,'quantityordered': 12}}];
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockBundleRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[1]).mockReturnValueOnce(mockRows[2]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseRows[1]).mockReturnValueOnce(mockWareHouseUnavailableRows[2]).mockReturnValueOnce(mockWareHouseUnavailableRows[3]);
+            callback();
             expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockBundleRow.vars.bundle_name}`+
             ` ${mockBundleRow.vars.price}`+
             `\n2) ${mockRows[0].vars.bundle_name}`+
             ` ${mockRows[0].vars.price}`+
+            '\n');
+        });
+        it('should display only available bundles if the menu choosed allow enrollment',()=>{
+            var mockWareHouseUnavailableRows = [{vars: {'bundleId': '-2009','bundleInputId': '-1709','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input','quantityavailable': 10,'quantityordered': 10}},{vars: {'bundleId': '-9009','bundleInputId': '-5709','bundle_name': 'third possible name bundle','price': '6251','input_name': 'third input','quantityavailable': 10,'quantityordered': 10}},{vars: {'bundleId': '-1009','bundleInputId': '-8709','bundle_name': 'fourth possible name bundle','price': '5251','input_name': 'fourth input','quantityavailable': 2,'quantityordered': 2}},{vars: {'bundleId': '-2009','bundleInputId': '-18909','bundle_name': 'Second possible name bundle','price': '2251','input_name': 'second input','quantityavailable': 10,'quantityordered': 12}}];
+            mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false).mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+            mockCursor.next.mockReturnValueOnce(mockBundleRow).mockReturnValueOnce(mockRows[0]).mockReturnValueOnce(mockRows[1]).mockReturnValueOnce(mockRows[2]).mockReturnValueOnce(mockWareHouseRows[0]).mockReturnValueOnce(mockWareHouseUnavailableRows[1]).mockReturnValueOnce(mockWareHouseUnavailableRows[2]).mockReturnValueOnce(mockWareHouseUnavailableRows[3]);
+            callback();
+            expect(state.vars.main_menu).toEqual(`Select a product\n1) ${mockBundleRow.vars.bundle_name}`+
+            ` ${mockBundleRow.vars.price}`+
             '\n');
         });
         
@@ -864,6 +960,12 @@ describe('clientRegistration', () => {
         it('should prompt for the farmer\'s national Id', () => {
             clientRegistration.start(account, country, reg_lang);
             expect(promptDigits).toHaveBeenCalledWith(nationalIdHandler.handlerName);
+            expect(promptDigits).toHaveBeenCalledTimes(1);
+        });
+    });
+    describe('continue to enroll', () => {
+        it('should prompt for digits if the user chooses to continue to enroll',()=>{
+            clientRegistration.onContinueToEnroll();
             expect(promptDigits).toHaveBeenCalledTimes(1);
         });
     });

--- a/client-registration/continue/continue.js
+++ b/client-registration/continue/continue.js
@@ -1,12 +1,33 @@
 var notifyELK = require('../../notifications/elk-notification/elkNotification');
 var handlerName = 'continue_enrollment';
+
+var getWarehouse = function(districtName){
+    var table  = project.initDataTableById(service.vars.districtWarehouseTableId);
+    var cursor = table.queryRows({vars: {'districtname': districtName}});
+    if(cursor.hasNext()){
+        var row = cursor.next();
+        var varietyTable = project.initDataTableById(service.vars.districtVarietyTableId);
+        var varietyWarehouseCursor = varietyTable.queryRows({vars: {'districtname': districtName}});
+        if(varietyWarehouseCursor.hasNext()){
+            var varietyRow = varietyWarehouseCursor.next();
+            state.vars.varietyWarehouse = varietyRow.vars.warehouse;
+        }
+        return row.vars.warehouse;
+    }
+    else{
+        return false;
+    }
+};
 module.exports = {
     handlerName: handlerName,
     getHandler: function(onContinueToEnroll){
         return function (input) {  
             notifyELK();
             if(input == 1){
-                onContinueToEnroll();
+                state.vars.warehouse = getWarehouse(JSON.parse(state.vars.client_json).DistrictName);
+                if(state.vars.warehouse != false){ 
+                    onContinueToEnroll();
+                }
             }
             else{
                 stopRules();

--- a/client-registration/continue/continue.test.js
+++ b/client-registration/continue/continue.test.js
@@ -1,13 +1,23 @@
 const {getHandler} = require('./continue');
 var notifyELK = require('../../notifications/elk-notification/elkNotification');
+var {client}  = require('../../client-enrollment/test-client-data'); 
 
 jest.mock('../../notifications/elk-notification/elkNotification');
 describe('continueHandler', () => {
     let onContinueToEnroll;
     var continueHandler;
+    state.vars.client_json = JSON.stringify(client);
+    var wareHouseRow = {vars: {'warehouse': 'name'}};
+    var mockTable = { createRow: jest.fn(), queryRows: jest.fn()};
+    var mockCursor = {next: jest.fn(), hasNext: jest.fn()};
+    beforeAll(()=>{
+        project.initDataTableById = jest.fn().mockReturnValue(mockTable);
+        mockTable.queryRows.mockReturnValue(mockCursor);
+    });
     beforeEach(() => {
         onContinueToEnroll = jest.fn();
         continueHandler = getHandler(onContinueToEnroll);
+        mockCursor.hasNext.mockReturnValue(false);
     });
     it('should return a function', () => {
         expect(getHandler(onContinueToEnroll)).toBeInstanceOf(Function);
@@ -17,8 +27,16 @@ describe('continueHandler', () => {
         expect(notifyELK).toHaveBeenCalled();
     });
     it('should call onContinueToEnroll if the user press 1', () => {
+        mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(false);
+        mockCursor.next.mockReturnValueOnce(wareHouseRow);
         continueHandler(1);
         expect(onContinueToEnroll).toHaveBeenCalled();
+    });
+    it('should set the state.vars.varietyWarehouse if available onContinueToEnroll if the user press 1', () => {
+        mockCursor.hasNext.mockReturnValueOnce(true).mockReturnValueOnce(true);
+        mockCursor.next.mockReturnValueOnce(wareHouseRow).mockReturnValueOnce(wareHouseRow);
+        continueHandler(1);
+        expect(state.vars.varietyWarehouse).toBe(wareHouseRow.vars.warehouse);
     });
     it('should not call onContinueToEnroll if the user doesn\'t press 1', () => {
         continueHandler(2);

--- a/just-in-time/account-number-handler/accountNumberHandler.test.js
+++ b/just-in-time/account-number-handler/accountNumberHandler.test.js
@@ -64,8 +64,16 @@ describe('account_number_handler', () => {
     });
     it('should  display a message saying that the client did not enroll if the account number is not valid', () => {
         mockCursor.hasNext.mockReturnValue(false);
-        rosterAPI.getClient.mockReturnValueOnce(false);
+        rosterAPI.authClient.mockReturnValueOnce(false);
         accountNumberHandler(inValidAccount);
+        expect(sayText).toHaveBeenCalledWith('Farmer is not enrolled this season. Please try again.');
+        expect(stopRules).toHaveBeenCalled();
+    });
+    
+    it('should  display a message saying that the client did not enroll if the current season is different from the season received from their account', () => {
+        client.BalanceHistory[0].SeasonName = '2020, Long Rain';
+        rosterAPI.getClient.mockReturnValue(false);
+        accountNumberHandler(validAccountNumber);
         expect(sayText).toHaveBeenCalledWith('Farmer is not enrolled this season. Please try again.');
         expect(stopRules).toHaveBeenCalled();
     });
@@ -133,5 +141,13 @@ describe('account_number_handler', () => {
         mockCursor.hasNext.mockReturnValueOnce(false).mockReturnValueOnce(false).mockReturnValueOnce(false);
         accountNumberHandler(validAccountNumber);
         expect(onAccountNumberValidated).not.toHaveBeenCalled();
+    });
+    it('should  display a message saying that the client did not enroll if the account number is not valid', () => {
+        mockCursor.hasNext.mockReturnValue(false);
+        client.BalanceHistory.length = 0;
+        rosterAPI.getClient.mockReturnValueOnce(client);
+        accountNumberHandler(inValidAccount);
+        expect(sayText).toHaveBeenCalledWith('Farmer is not enrolled this season. Please try again.');
+        expect(stopRules).toHaveBeenCalled();
     });
 });

--- a/just-in-time/bundle-choice-handler/bundleChoiceHandler.test.js
+++ b/just-in-time/bundle-choice-handler/bundleChoiceHandler.test.js
@@ -54,6 +54,20 @@ describe('order confirmation handler test', ()=>{
         expect(sayText).toHaveBeenCalledWith(inputMenu[1]);
         expect(promptDigits).toHaveBeenCalledWith(handlerName);
     });
+    it('should not display a menu page if the input is 77 and the next menu doesn\'t exists',()=>{
+        state.vars.multiple_input_menus = true;
+        state.vars.input_menu_loc = 3;
+        state.vars.input_menu_length = 3;
+        state.vars.input_menu = JSON.stringify(inputMenu);
+        bundleChoiceHandler(77);
+        expect(sayText).not.toHaveBeenCalled();
+    });
+    it('should not set state.vars.chosenMaizeBundle bundle if the quantity is not defined ',()=>{
+        state.vars.multiple_input_menus = false;
+        state.vars.chosenMaizeBundle = undefined;
+        bundleChoiceHandler(2);
+        expect(state.vars.chosenMaizeBundle).toBeUndefined();
+    });
 
 
 });

--- a/just-in-time/justInTime.js
+++ b/just-in-time/justInTime.js
@@ -261,11 +261,15 @@ function onOrderConfirmed(){
         orderPlaced.forEach(function(element){
             var stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': element.bundleName}});
             if(stockCursor.hasNext()){
+                console.log('found');
                 var row = stockCursor.next();
                 row.vars.quantityordered =  row.vars.quantityordered + 1;
+                console.log('old quantity:--------------'+row.vars.quantityordered+ 'product:-----------'+element.bundleName+'warehouse:'+state.vars.warehouse+ service.vars.warehouseStockTableId);
                 row.save();
             } 
+            console.log('old quantity:--------------not found'+ 'product:-----------'+element.bundleName+'warehouse:'+state.vars.warehouse+ service.vars.warehouseStockTableId);
         });
+        console.log('not found');
         if(state.vars.chosenVariety != ' '){
             var varietyStockTable = project.initDataTableById(service.vars.varietyStockTableId);
             var vStockCursor = varietyStockTable.queryRows({vars: {'warehousename': state.vars.varietyWarehouse,'inputname': JSON.parse(state.vars.chosenVariety).inputName}});

--- a/just-in-time/justInTime.js
+++ b/just-in-time/justInTime.js
@@ -261,15 +261,11 @@ function onOrderConfirmed(){
         orderPlaced.forEach(function(element){
             var stockCursor = bundleStockTable.queryRows({vars: {'warehousename': state.vars.warehouse,'bundlename': element.bundleName}});
             if(stockCursor.hasNext()){
-                console.log('found');
                 var row = stockCursor.next();
                 row.vars.quantityordered =  row.vars.quantityordered + 1;
-                console.log('old quantity:--------------'+row.vars.quantityordered+ 'product:-----------'+element.bundleName+'warehouse:'+state.vars.warehouse+ service.vars.warehouseStockTableId);
                 row.save();
-            } 
-            console.log('old quantity:--------------not found'+ 'product:-----------'+element.bundleName+'warehouse:'+state.vars.warehouse+ service.vars.warehouseStockTableId);
+            }
         });
-        console.log('not found');
         if(state.vars.chosenVariety != ' '){
             var varietyStockTable = project.initDataTableById(service.vars.varietyStockTableId);
             var vStockCursor = varietyStockTable.queryRows({vars: {'warehousename': state.vars.varietyWarehouse,'inputname': JSON.parse(state.vars.chosenVariety).inputName}});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
(https://oneacrefund.atlassian.net/browse/MOB-156)
Updated the KE registration to check the warehouse before showing the products to the user just like JiT service
To test here: https://telerivet.com/p/0c6396c9/service/SVc3c8d451e239d756/edit
Dial with the account number 13983972

- Choose option 3 for registration

- Enter 0 for registering a new client 

- Enter any 8 digit national ID

- Enter any First and last name

- Use any phone number starting with: 07**********

- Enter 1 to continue

The list showing up matches products available in the Bungoma district on this [table](https://telerivet.com/p/0c6396c9/data/dev_5FJIT_5FWarehouse_5Fstock?sort=&f[vars.warehousename]=Bungoma+Three)
Finish ordering, the chosen products should be incremented on ordered column on the above table
