### PR TITLE
HOTFIX-Removed ordering redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## New Version
 
+### v1.6.4
+### Changed
+* [MOB-157](https://oneacrefund.atlassian.net/browse/MOB-157) Remove the menu redirection to products from RW enrollment
+
 ### v1.6.3
 ### Added
 * [MOB-150](https://oneacrefund.atlassian.net/browse/MOB-150) Make JiT Top-Up and Enrollment invisible on Client Menu

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/rw-legacy/core.js
+++ b/rw-legacy/core.js
@@ -1169,7 +1169,7 @@ addInputHandler('reg_group_constitution_confirm',function(input){
             console.log('is gl? : ' + is_gl);
             var enr_msg = msgs('enr_reg_complete', { '$ACCOUNT_NUMBER': state.vars.account_number, '$NAME': state.vars.reg_name_2 }, lang);
             sayText(enr_msg);
-            promptDigits('reg_end_ordering_redirect', { 'submitOnHash': false, 'maxDigits': max_digits_for_input, 'timeout': timeout_length });
+            //promptDigits('reg_end_ordering_redirect', { 'submitOnHash': false, 'maxDigits': max_digits_for_input, 'timeout': timeout_length });
             //retreive ads per district entered by the user
             var retrieveAd = require('./lib/enr-retrieve-ad-by-district');
             var districtId = state.vars.districtId;

--- a/rw-legacy/lib/utils/message-translations.js
+++ b/rw-legacy/lib/utils/message-translations.js
@@ -340,8 +340,8 @@ module.exports = {
         "ki": "Nomero iranga umuyobozi w'itsinda wanditse siyo. Ongera ugerageze",
     },
     "enr_reg_complete": {
-        "en": "Thank you for enrolling with TUBURA! Your account number is $ACCOUNT_NUMBER. Please save this!~B1)Continue~B99)Exit",
-        "ki": "Murakoze kwiyandikisha, $NAME. Bwira umuhinzi nimero ya konti ya TUBURA: $ACCOUNT_NUMBER.~B1)Gukomeza~B99)Kuvamo",
+        "en": "Thank you for enrolling with TUBURA! Your account number is $ACCOUNT_NUMBER. Please save this!",
+        "ki": "Murakoze kwiyandikisha, $NAME. Bwira umuhinzi nimero ya konti ya TUBURA: $ACCOUNT_NUMBER.",
     },
     "enr_bad_input_increment": {
         "en": "invalid increment~B1)Continue~B99)Exit",


### PR DESCRIPTION
Removes product list redirection menu from the registration as people shouldn't be confirming orders
To test: [here](https://telerivet.com/p/8799a79f/service/SV1161debc042a9de0/edit)
Press 1 to register a new client
Go through registration steps: 16 digits national Id, for group code: 32646*008*00312
you shouldn't be redirected to product list