### PR TITLE
HOTFIX: fixing the pshop shs activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file. 
 
 ## New Version
+## v1.9.8
+
+### Fixed
+* [ESWFA-90](https://oneacrefund.atlassian.net/browse/ESWFA-90) Rw pshops clients can't get the shs activation codes
 
 ## v1.9.7
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2422,7 +2422,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -2781,6 +2782,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -4162,6 +4164,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -4944,7 +4947,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/rw-legacy/lib/psh-reg-check.js
+++ b/rw-legacy/lib/psh-reg-check.js
@@ -70,7 +70,11 @@ module.exports = function(accnum){
             ActList = Activationtable.queryRows({
                 vars: activationVars,
             });
-            if(ActList.count() == 0){
+            if(ActList.count() == 0){ 
+                Serial.vars.accountnumber = null;
+                Serial.vars.dateregistered = null;
+                Serial.vars.historic_credit = null;
+                Serial.save();
                 admin_alert('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes', 'marisa');
                 slack.log('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes');
                 console.log('No rows in ActTable for serial no: ' + state.vars.serial_no, 'Missing Serial Number in ActivationCodes');

--- a/rw-legacy/lib/psh-renew-code.js
+++ b/rw-legacy/lib/psh-renew-code.js
@@ -50,13 +50,13 @@ module.exports = function(accnum, serial_no){
         'dateactivated' : {exists : 1}
     }
     // If the the product type is not nul check if it s biolite
-    if(serial.vars.product_type != null){
-        activationCodeVars['product_type'] = {'ne': 'biolite'};
-        // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
-        if(serial.vars.product_type == 'biolite'){
-            activationCodeVars['product_type'] = 'biolite';
-        }
-    }
+    // if(serial.vars.product_type != null){
+    //     activationCodeVars['product_type'] = {'ne': 'biolite'};
+    //     // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+    //     if(serial.vars.product_type == 'biolite'){
+    //         activationCodeVars['product_type'] = 'biolite';
+    //     }
+    // }
     // the section below checks how long ago the past activation code was given
     // initialize variables
     var act_pointer = act_table.queryRows({
@@ -120,17 +120,17 @@ module.exports = function(accnum, serial_no){
         // Taking into consideration the biolite product type
         var listActVars = {
             'serialnumber': serial_no,
-            'type': "Unlock",
+            'unlock': "Yes",
             'activated': "No"
         }
         // If the the product type is not nul check if it s biolite
-        if(serial.vars.product_type != null){
-            listActVars['product_type'] = {'ne': 'biolite'};
-            // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
-            if(serial.vars.product_type == 'biolite'){
-                listActVars['product_type'] = 'biolite';
-            }
-        }
+        // if(serial.vars.product_type != null){
+        //     listActVars['product_type'] = {'ne': 'biolite'};
+        //     // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+        //     if(serial.vars.product_type == 'biolite'){
+        //         listActVars['product_type'] = 'biolite';
+        //     }
+        // }
         var ListAct = act_table.queryRows({
             vars: listActVars
         });
@@ -138,17 +138,17 @@ module.exports = function(accnum, serial_no){
             // Taking into consideration the biolite product type
             var listActVars ={
                 'serialnumber': serial_no,
-                'type': "Unlock",
+                'unlock': 'Yes',
                 'activated': {exists : 0},
             }
             // If the the product type is not nul check if it s biolite
-            if(serial.vars.product_type != null){
-                listActVars['product_type'] = {'ne': 'biolite'};
-                // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
-                if(serial.vars.product_type == 'biolite'){
-                    listActVars['product_type'] = 'biolite';
-                }
-            }
+            // if(serial.vars.product_type != null){
+            //     listActVars['product_type'] = {'ne': 'biolite'};
+            //     // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+            //     if(serial.vars.product_type == 'biolite'){
+            //         listActVars['product_type'] = 'biolite';
+            //     }
+            // }
             var ListAct = act_table.queryRows({
                 vars: listActVars
             });
@@ -162,17 +162,17 @@ module.exports = function(accnum, serial_no){
         // Taking into consideration the biolite product type
         var listActVars = {
             'serialnumber': serial_no,
-            'type': "Activation",
+            'unlock': {ne: 'Yes'},
             'activated': "No",
         }
         // If the the product type is not nul check if it s biolite
-        if(serial.vars.product_type != null){
-            listActVars['product_type'] = {'ne': 'biolite'};
-            // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
-            if(serial.vars.product_type == 'biolite'){
-                listActVars['product_type'] = 'biolite';
-            }
-        }
+        // if(serial.vars.product_type != null){
+        //     listActVars['product_type'] = {'ne': 'biolite'};
+        //     // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+        //     if(serial.vars.product_type == 'biolite'){
+        //         listActVars['product_type'] = 'biolite';
+        //     }
+        // }
         var ListAct = act_table.queryRows({
             vars: listActVars
         });  
@@ -181,17 +181,17 @@ module.exports = function(accnum, serial_no){
             // Taking into consideration the biolite product type
             var listActVars = {
                 'serialnumber': serial_no,
-                'type': "Activation",
+                'unlock': {ne: 'Yes'},
                 'activated': {exists : 0},
             }
             // If the the product type is not nul check if it s biolite
-            if(serial.vars.product_type != null){
-                listActVars['product_type'] = {'ne': 'biolite'};
-                // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
-                if(serial.vars.product_type == 'biolite'){
-                    listActVars['product_type'] = 'biolite';
-                }
-            }   
+            // if(serial.vars.product_type != null){
+            //     listActVars['product_type'] = {'ne': 'biolite'};
+            //     // If the product type is biolite in the serial table, look for not only a serial that match product type is biolite 
+            //     if(serial.vars.product_type == 'biolite'){
+            //         listActVars['product_type'] = 'biolite';
+            //     }
+            // }   
             var ListAct = act_table.queryRows({
                 vars: listActVars
             });

--- a/rw-legacy/lib/psh-serial-verify.js
+++ b/rw-legacy/lib/psh-serial-verify.js
@@ -25,12 +25,10 @@ module.exports = function(accnum, serial_no){
         Serial.vars.historic_credit = state.vars.TotalCredit - state.vars.Balance;
         Serial.vars.dateregistered = new Date().toString();
         if(!state.vars.duplicate){Serial.vars.product_type = 'biolite';}
-        Serial.save(); 
-        
         // retrieve one unused activation code for this serial number
         var ActTable = project.getOrCreateDataTable(service.vars.activation_code_table);
         var listVars = {'serialnumber': serial_no,
-            'type': 'Activation',
+            'unlock': {ne: 'Yes'},
         };
         // if(!state.vars.duplicate){listVars.vars.product_type = 'biolite';} // because only biolite products are being sold now
 
@@ -39,7 +37,7 @@ module.exports = function(accnum, serial_no){
         });
 
         var Act = null;
-        if(ListAct.hasNext()) {
+        while(ListAct.hasNext()) {
             var row = ListAct.next();
             if(row.vars.activated !== 'Yes') {
                 Act = row;
@@ -55,6 +53,7 @@ module.exports = function(accnum, serial_no){
             state.vars.ActCode = Act.vars.code;
             Act.vars.activated = 'Yes';
             Act.vars.dateactivated = new Date().toString();
+            Serial.save(); 
             Act.save();
         }
         // update the activation table to say that this code has been used


### PR DESCRIPTION
currently, the clients are unable to get activation codes, due to the way the new activation codes were uploaded without the `type` column. I have changed this to keep use of `unlock` column to be Yes or No instead of relying on both unlock and type.

I have also commented out the check for type='biolite' since all products are now biolite and some of the products do not have the value `biolite` by default.