### PR TITLE
MOB-407-Handle invalid shs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## New Version
 
+## v1.10.4
+* [MOB-407] (https://oneacrefund.atlassian.net/browse/MOB-407) Handle additional Validation for wrong shs
 ## v1.10.3
 * [ESWFA-93](https://oneacrefund.atlassian.net/browse/ESWFA-93) Add an IPP option to the non farmer USSD menu
 ## v1.10.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-sms",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/shs/endpoints/registerSerial.js
+++ b/shs/endpoints/registerSerial.js
@@ -23,7 +23,7 @@ module.exports = function (requestData){
             global.sayText(translate('serial_assigned',{'$serialNumber': requestData.unitSerialNumber},state.vars.shsLang));
             return null;
         }
-        else if(JSON.parse(response.content).message == 'No unit found with serial number '+ requestData.unitSerialNumber || JSON.parse(response.content).message =='Unit with serial number '+ requestData.unitSerialNumber +' is not an OAF unit'){
+        else if(JSON.parse(response.content).message == 'No unit found with serial number '+ requestData.unitSerialNumber || JSON.parse(response.content).message =='Unit with serial number '+ requestData.unitSerialNumber +' is not an OAF unit' || JSON.parse(response.content).message == 'validation failed'){
             logger = new Log();
             logger.error('Failed to register shs unit', {data: {response: response, request: requestData}});
             return 'wrong serial';


### PR DESCRIPTION
Before a serial number containing letters like: SHX-14788199 was being validated on the endpoint but not in Telerivet. This resulted with a message saying "USSD request received" instead of prompting for another input. This PR corrects that.

To Test [here](https://telerivet.com/p/0c6396c9/service/SVb47209de1fdd2cf0/edit):
Enter account number: 25069548
Choose Solar option
Choose Register shs: 1
Choose new SHS: 1
Enter a wrong shs unit: SHX-14788199
You should be prompt to enter another one

The same fails on the test/live service: [here](https://telerivet.com/p/0c6396c9/service/SVbc04709b5abb48c0/edit) 