### PR TITLE
Fixing popup translation

### DIFF
--- a/kenya-impact-trainings/translations/index.js
+++ b/kenya-impact-trainings/translations/index.js
@@ -5,6 +5,6 @@ module.exports = {
     },
     'trainings_welcome_message': {
         'en': 'Congratulations $name on your first step towards becoming a smart farmer! A training SMS has been sent to your phone. Start your learning journey now!',
-        'sw': 'Hongera $name kwa hatua yako ya kwanza kuelekea kuwa mkulima mwerevu! Ujumbe wa mafunzo umetumwa kwa simu yako. Anza safari yako ya kujifunza sasa!'
+        'sw': 'Hongera $name kwa hatua yako ya kwanza kuelekea kuwa mkulima mwenye maarifa! Ujumbe wa mafunzo umetumwa kwa simu yako. Anza safari yako ya kujifunza sasa.'
     }
 };


### PR DESCRIPTION
currently the popup after selecting the training is  changed to the next message for swahili
```
Hongera [farmer's name] kwa hatua yako ya kwanza kuelekea kuwa mkulima mwenye maarifa!
 Ujumbe wa mafunzo umetumwa kwa simu yako. Anza safari yako ya kujifunza sasa.
```

dial in the ussd
https://telerivet.com/p/0c6396c9/service/SV3c5034dacfc21c61/edit
- enter 99 to change to swahili
- enter 0 to access the non clients menu
- choose 2 for trainings
- enter phone: 0700010006 to access trainings menu
- the order of trainings on the menu should be
```
1:Kupanda Mahindi/Maharagwe
2:TopDress
3:Wadudu/Magonjwa
4:Kuvuna Mahindi
```
and not any other order

and upon selecting any training, there should be a popup message as shown above if you have choosen swahili